### PR TITLE
Use docker to build service PHP client

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,14 @@ The project structure is based on [`drupal-composer/drupal-project`](https://git
 	2. Run `docker-compose build`
 	3. Run `docker-compose up`
 3. Profit!
+
+## Webservice client generation
+
+To generate a PHP webservice client for accessing [the community service](https://github.com/DBCDK/dbc-community-service) run the following command:
+
+`docker-compose run swagger generate -i http://service:3000/explorer/swagger.json -l php -o /var/usr/client -c /var/usr/swagger/config.json`
+
+Afterwards remember to fix file permissions.
+
+Note that this generates quite a lot of noise in the log. The process completes
+anyhow.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,3 +49,11 @@ service_db:
     POSTGRES_DB: db
     POSTGRES_USER: db
     POSTGRES_PASSWORD: qiBme2Zjsp1fEwwD
+swagger:
+  image: moander/swagger-codegen
+  volumes:
+    - './docker/swagger/config.json:/var/usr/swagger/config.json:ro'
+    # This is where the client code will be generated
+    - './lib/client:/var/usr/client'
+  links:
+    - service

--- a/docker/service/Dockerfile
+++ b/docker/service/Dockerfile
@@ -3,7 +3,8 @@ FROM node:5.6
 # The original repo requires the database to run on the same host as the app
 # This fork/branch allows for configuration of database through environment
 # variables. Thus we can run postgres on a separate host using standard images.
-RUN git clone https://github.com/kasperg/dbc-community-service.git -b env_config /usr/src/app
+# Also we need to update the loopback explorer to get Swagger 2.0 specification.
+RUN git clone https://github.com/kasperg/dbc-community-service.git -b biblo-admin /usr/src/app
 WORKDIR /usr/src/app
 
 RUN npm install

--- a/docker/swagger/config.json
+++ b/docker/swagger/config.json
@@ -1,0 +1,6 @@
+{
+  "apiPackage": "DBCDK\\CommunityServices",
+  "modelPackage": "DBCDK\\CommunityServices\\Model",
+  "packagePath": "",
+  "srcBasePath": ""
+}


### PR DESCRIPTION
Add the swagger-codegen container and link it to the service. We name it
swagger as the container entrypoint is the swagger command.

Add documentation about how to run the command.
