### PR TITLE
Add support for "secret" docker-compose env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 !/web/modules/custom
 !/web/themes/custom
 !/web/profiles/custom
+
+# Ignore Docker Compose override file to provide secret keys.
+docker-compose.override.yml

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ The project structure is based on [`drupal-composer/drupal-project`](https://git
 1. Clone this repository
 2. From the root of the cloned repository:
   1. Run `composer install`
-	2. Run `docker-compose build`
-	3. Run `docker-compose up`
+  2. Copy `example.docker-compose.override.yml` to `docker-compose.override.yml` and fill out the required information.
+  3. Run `docker-compose build`
+  4. Run `docker-compose up`
 3. Profit!
 
 ## Webservice client generation

--- a/README.md
+++ b/README.md
@@ -14,10 +14,13 @@ The project structure is based on [`drupal-composer/drupal-project`](https://git
 1. Clone this repository
 2. From the root of the cloned repository:
   1. Run `composer install`
-  2. Copy `example.docker-compose.override.yml` to `docker-compose.override.yml` and fill out the required information.
-  3. Run `docker-compose build`
-  4. Run `docker-compose up`
+  2. Run `docker-compose build`
+  3. Run `docker-compose up`
 3. Profit!
+
+### Optional installation instructions
+
+* If you wish to provide "real data" instead of using "dummy fallbacks", then copy `example.docker-compose.override.yml` to `docker-compose.override.yml` and fill out the required enviroment variables.
 
 ## Webservice client generation
 

--- a/example.docker-compose.override.yml
+++ b/example.docker-compose.override.yml
@@ -1,0 +1,5 @@
+service:
+  environment:
+    AMAZON_S3_KEYID: AmazonS3KeyId
+    AMAZON_S3_KEY: AmazonS3Key
+    UNILOGINSECRET: UniLoginSecret


### PR DESCRIPTION
Ignore docker-compose.override.yml so we can provide secret docker environment variables.

Provide an example file to show what information that should be overridden.
