### PR TITLE
Disable image scaling queue in community service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ service:
     AMAZON_S3_KEYID: AmazonS3KeyId
     AMAZON_S3_KEY: AmazonS3Key
     UNILOGINSECRET: UniLoginSecret
+    DISABLE_IMAGE_SCALING_QUEUE: 1
   links:
     - service_db
 service_db:

--- a/example.docker-compose.override.yml
+++ b/example.docker-compose.override.yml
@@ -3,3 +3,4 @@ service:
     AMAZON_S3_KEYID: AmazonS3KeyId
     AMAZON_S3_KEY: AmazonS3Key
     UNILOGINSECRET: UniLoginSecret
+    DISABLE_IMAGE_SCALING_QUEUE: 1


### PR DESCRIPTION
It requires a locally run Redis which is not available in our Docker
environment. It is not a required dependency so we use an environment
variable to disable it. This removes connection errors in the log.
