### PR TITLE
Only admins should be able to create new users

### DIFF
--- a/web/config/sync/user.settings.yml
+++ b/web/config/sync/user.settings.yml
@@ -9,7 +9,7 @@ notify:
   register_admin_created: true
   register_no_approval_required: true
   register_pending_approval: true
-register: visitors_admin_approval
+register: admin_only
 cancel_method: user_cancel_block
 password_reset_timeout: 86400
 password_strength: true


### PR DESCRIPTION
We do not want anonymous users spamming registrations.
