### PR TITLE
Page Manager & DBC Community Development module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "drupal/core": "8.0.*",
         "drush/drush": "~8.0",
         "drupal/console": "~0.10",
-        "drupal/adminimal_theme": "^8.1"
+        "drupal/adminimal_theme": "^8.1",
+        "drupal/page_manager": "^8.1"
     },
     "require-dev": {
         "behat/behat": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "c63b68c86d04448ceae33f7e338ac496",
-    "content-hash": "e8aeaa1bc3ad9033c77f84d4fa869e55",
+    "hash": "6aabad818eee7fbaabdcfa54fccc2213",
+    "content-hash": "50de6b590484edb6b1d738c398e61e7f",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -1022,6 +1022,88 @@
             ],
             "description": "Drupal is an open source content management platform powering millions of websites and applications.",
             "time": "2016-02-24 18:59:52"
+        },
+        {
+            "name": "drupal/ctools",
+            "version": "8.3.0-alpha23",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupal.org/project/ctools",
+                "reference": "1eb136e1989b79283d9af8a0a2781ec6a9a3c866"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/ctools-8.x-3.0-alpha23.zip",
+                "reference": null,
+                "shasum": null
+            },
+            "require": {
+                "drupal/core": "8.*"
+            },
+            "replace": {
+                "drupal/ctools_block": "self.version",
+                "drupal/ctools_views": "self.version"
+            },
+            "suggest": {
+                "drupal/block": "Required by drupal/ctools_views",
+                "drupal/core": "Required by drupal/ctools_block, drupal/ctools_views",
+                "drupal/views": "Required by drupal/ctools_views"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-8.x-3.x": "8.3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.drupal-composer.org/downloads/",
+            "description": "Provides a number of utility and helper APIs for Drupal developers and site builders.",
+            "homepage": "https://www.drupal.org/project/ctools"
+        },
+        {
+            "name": "drupal/page_manager",
+            "version": "8.1.0-alpha23",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupal.org/project/page_manager",
+                "reference": "fed1710d1b366bb3417b197270c6d73caeae4fa1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/page_manager-8.x-1.0-alpha23.zip",
+                "reference": null,
+                "shasum": null
+            },
+            "require": {
+                "drupal/block": "8.*",
+                "drupal/core": "8.*",
+                "drupal/ctools": "~8.3.0-alpha21"
+            },
+            "replace": {
+                "drupal/page_manager_ui": "self.version"
+            },
+            "suggest": {
+                "drupal/core": "Required by drupal/page_manager_ui"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-8.x-1.x": "8.1.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.drupal-composer.org/downloads/",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Tim Plunkett",
+                    "homepage": "https://www.drupal.org/u/tim.plunkett",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "Provides a way to place blocks on a custom page.",
+            "homepage": "https://www.drupal.org/project/page_manager",
+            "time": "2016-02-16 19:47:59"
         },
         {
             "name": "drush/drush",

--- a/web/config/sync/core.extension.yml
+++ b/web/config/sync/core.extension.yml
@@ -2,6 +2,7 @@ module:
   basic_auth: 0
   block: 0
   breakpoint: 0
+  ctools: 0
   dbcdk_community: 0
   dblog: 0
   dynamic_page_cache: 0
@@ -11,6 +12,8 @@ module:
   link: 0
   node: 0
   page_cache: 0
+  page_manager: 0
+  page_manager_ui: 0
   rest: 0
   serialization: 0
   shortcut: 0

--- a/web/config/sync/core.extension.yml
+++ b/web/config/sync/core.extension.yml
@@ -13,7 +13,6 @@ module:
   node: 0
   page_cache: 0
   page_manager: 0
-  page_manager_ui: 0
   rest: 0
   serialization: 0
   shortcut: 0

--- a/web/config/sync/page_manager.page.node_view.yml
+++ b/web/config/sync/page_manager.page.node_view.yml
@@ -1,0 +1,17 @@
+uuid: 75787784-0219-4300-bd00-dc4e5e1fc7fc
+langcode: en
+status: false
+dependencies: {  }
+_core:
+  default_config_hash: 1rbdWeEeBjGARzFlodw9zcw3FlX6WQD83Rsckxl9_3o
+id: node_view
+label: 'Node view'
+use_admin_theme: false
+path: '/node/{node}'
+access_logic: and
+access_conditions: {  }
+parameters:
+  node:
+    machine_name: node
+    type: 'entity:node'
+    label: Node

--- a/web/modules/custom/dbcdk_community/src/CommunityApiConfiguration.php
+++ b/web/modules/custom/dbcdk_community/src/CommunityApiConfiguration.php
@@ -33,11 +33,8 @@ class CommunityApiConfiguration extends Configuration {
     $this->setHost($host);
 
     // Set Debug Mode if it is enabled in the admin form.
-    // The form type "checkbox" return 0 or 1 as its values for true and false
-    // but the API says it requires a boolean, so we cannot simply use the
-    // value and therefor have to define it ourselves.
     if ($config->get('community_service_debug')) {
-      $this->setDebug(TRUE);
+      $this->setDebug((bool) $config->get('community_service_debug'));
     }
   }
 

--- a/web/modules/custom/dbcdk_community/src/CommunityApiConfiguration.php
+++ b/web/modules/custom/dbcdk_community/src/CommunityApiConfiguration.php
@@ -26,10 +26,19 @@ class CommunityApiConfiguration extends Configuration {
     parent::__construct();
 
     $config = \Drupal::config('dbcdk_community.settings');
+
     // The Community Service prefixes each endpoint with a slash,
     // so we make sure the host does not end with one.
     $host = rtrim($config->get('community_service_url'), '/');
     $this->setHost($host);
+
+    // Set Debug Mode if it is enabled in the admin form.
+    // The form type "checkbox" return 0 or 1 as its values for true and false
+    // but the API says it requires a boolean, so we cannot simply use the
+    // value and therefor have to define it ourselves.
+    if ($config->get('community_service_debug')) {
+      $this->setDebug(TRUE);
+    }
   }
 
 }

--- a/web/modules/custom/dbcdk_community/src/Form/SettingsForm.php
+++ b/web/modules/custom/dbcdk_community/src/Form/SettingsForm.php
@@ -43,12 +43,29 @@ class SettingsForm extends ConfigFormBase {
   public function buildForm(array $form, FormStateInterface $form_state) {
     $config = $this->config('dbcdk_community.settings');
 
+    // Community service host url.
     $form['community_service_url'] = array(
       'community_service_url' => array(
         '#type' => 'textfield',
         '#title' => $this->t('Community Service Url'),
         '#default_value' => $config->get('community_service_url'),
         '#description' => $this->t('The Community Service Url until the endpoints start. Example: %example', array('%example' => 'https://dbcdk-community.dk/api/')),
+      ),
+    );
+
+    // Vertical tab for advanced options.
+    $form['advanced_options'] = array(
+      '#type' => 'details',
+      '#title' => $this->t('Advanced options'),
+    );
+
+    // Enable debug information.
+    $form['advanced_options']['community_service_debug'] = array(
+      'community_service_debug' => array(
+        '#type' => 'checkbox',
+        '#title' => $this->t('Community Service Debug-Mode'),
+        '#default_value' => $config->get('community_service_debug'),
+        '#description' => $this->t('Return debug information with each Community Service call.'),
       ),
     );
 
@@ -59,10 +76,18 @@ class SettingsForm extends ConfigFormBase {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
-    $this
-      ->config('dbcdk_community.settings')
-      ->set('community_service_url', $form_state->getValue(array('community_service_url')))
-      ->save();
+    $fields = [
+      'community_service_url',
+      'community_service_debug',
+    ];
+
+    foreach ($fields as $field) {
+      $this
+        ->config('dbcdk_community.settings')
+        ->set($field, $form_state->getValue([$field]))
+        ->save();
+    }
+
     parent::submitForm($form, $form_state);
   }
 

--- a/web/modules/custom/dbcdk_community_devel/dbcdk_community_devel.info.yml
+++ b/web/modules/custom/dbcdk_community_devel/dbcdk_community_devel.info.yml
@@ -1,0 +1,9 @@
+name: 'DBCDK Community Devel'
+type: module
+description: 'This module enables development modules and settings that are relevant for the DBCDK Community module.'
+package: DBCDK
+version: 8.x-1.0
+core: 8.x
+dependencies:
+  - dbcdk_community
+  - page_manager_ui


### PR DESCRIPTION
- Add and enable Page Manager module _(The `page_manager.page.node_view.yml` is a default page the module offers and normally enables. I have disabled it, since we don't use nodes anyway)_.
- Add DBC Community Service Development module.

_**Edit:** This PR has expanded a bit in size. Because the Page Manager module doens't make much sense right now, without the UI, we combine a development module and Page manger to one PR._
