### PR TITLE
Correct code standards for Community Content

### DIFF
--- a/web/modules/custom/dbcdk_community/src/Plugin/Block/FlaggedContentList.php
+++ b/web/modules/custom/dbcdk_community/src/Plugin/Block/FlaggedContentList.php
@@ -9,9 +9,7 @@ namespace Drupal\dbcdk_community\Plugin\Block;
 
 use DBCDK\CommunityServices\ApiException;
 use Drupal\Core\Block\BlockBase;
-use Drupal\Core\Logger\LoggerChannelFactory;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Drupal\dbcdk_community\Content\FlaggableContent;
 use Drupal\dbcdk_community\Content\FlaggableContentRepository;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -93,7 +91,7 @@ class FlaggedContentList extends BlockBase implements ContainerFactoryPluginInte
         $this->t('Content'),
         $this->t('Active flags'),
         $this->t('Latest flag'),
-        $this->t('Flag comment')
+        $this->t('Flag comment'),
       ],
       '#data' => [],
       '#empty' => $this->t('There is currently no flagged content'),
@@ -113,11 +111,11 @@ class FlaggedContentList extends BlockBase implements ContainerFactoryPluginInte
     return [
       'table' => $table,
       'pager' => [
-        '#type' => 'pager'
+        '#type' => 'pager',
       ],
       '#cache' => [
         'max-age' => 0,
-      ]
+      ],
     ];
   }
 

--- a/web/modules/custom/dbcdk_community/tests/src/Unit/Content/FlaggableContentRepositoryTest.php
+++ b/web/modules/custom/dbcdk_community/tests/src/Unit/Content/FlaggableContentRepositoryTest.php
@@ -16,7 +16,7 @@ use Drupal\dbcdk_community\Content\FlaggableContentRepository;
 use Drupal\Tests\UnitTestCase;
 
 /**
- * Tests flaggable content retrieval
+ * Tests flaggable content retrieval.
  *
  * @group dbcdk_community
  */
@@ -81,21 +81,25 @@ class FlaggableContentRepositoryTest extends UnitTestCase {
     $post = (new Post())->setId(1);
     $unflagged_post = (new Post())->setId(2);
     $flag_post_map = [
-      0 => [ $unflagged_post ],
-      1 => [ $post ],
-      2 => [ $post ],
+      0 => [$unflagged_post],
+      1 => [$post],
+      2 => [$post],
     ];
 
     // This comment should have a single flag.
     $comment = (new Comment())->setId(1);
     $unflagged_comment = (new Comment())->setId(2);
     $flag_comment_map = [
-      3 => [ $comment ],
-      4 => [ $unflagged_comment ],
+      3 => [$comment],
+      4 => [$unflagged_comment],
     ];
 
     return [
-      [$flags, $flag_post_map, $flag_comment_map]
+      [
+        $flags,
+        $flag_post_map,
+        $flag_comment_map,
+      ],
     ];
   }
 
@@ -117,7 +121,7 @@ class FlaggableContentRepositoryTest extends UnitTestCase {
    */
   public function testErrorHandling() {
     $flag_api_stub = $this->getMock('DBCDK\CommunityServices\Api\FlagApi');
-    $flag_api_stub->method('flagFind')->willReturn([ new Flag() ]);
+    $flag_api_stub->method('flagFind')->willReturn([new Flag()]);
     $flag_api_stub->method('flagPrototypeGetPosts')->willThrowException(new ApiException());
 
     $logger_stub = $this->getMock('Psr\Log\LoggerInterface');

--- a/web/modules/custom/dbcdk_community/tests/src/Unit/Content/FlaggableContentTest.php
+++ b/web/modules/custom/dbcdk_community/tests/src/Unit/Content/FlaggableContentTest.php
@@ -14,7 +14,7 @@ use Drupal\dbcdk_community\Content\FlaggableContent;
 use Drupal\Tests\UnitTestCase;
 
 /**
- * Tests flaggable content
+ * Tests flaggable content.
  *
  * @group dbcdk_community
  */
@@ -27,7 +27,7 @@ class FlaggableContentTest extends UnitTestCase {
     $flaggable = new FlaggableContent(new Comment());
     $flag = (new Flag())->setId(1)->setTimeFlagged(new DateTime('now'));
     $flaggable->addFlag($flag);
-    $this->assertEquals([ $flag ], $flaggable->getFlags());
+    $this->assertEquals([$flag], $flaggable->getFlags());
   }
 
   /**


### PR DESCRIPTION
My PHP CodeSniffer with Drupal standards complained about:
- some declarations of `use` that... well.. was not being used :smile: 
- Missing comma's at the end of arrays.
- Punctuation in DocBlock titles.
- And the whitespace left and right of single value array elements that we discussed earlier @kasperg.
