### PR TITLE
Set xdebug.max_nesting_level to meet install.php requirements

### DIFF
--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && \
   apt-get install --no-install-recommends -y -q php5-xdebug && \
   echo "xdebug.remote_enable = 1" >> /etc/php5/mods-available/xdebug-config.ini && \
   echo "xdebug.remote_connect_back = 1" >> /etc/php5/mods-available/xdebug-config.ini && \
+  echo "xdebug.max_nesting_level = 256" >> /etc/php5/mods-available/xdebug-config.ini && \
   php5enmod xdebug && \
   php5enmod xdebug-config && \
   apt-get clean && \


### PR DESCRIPTION
If this is not set we are not able to complete the Drupal installer.
