### PR TITLE
Add requirements hook for service connection status

### DIFF
--- a/web/modules/custom/dbcdk_community/dbcdk_community.install
+++ b/web/modules/custom/dbcdk_community/dbcdk_community.install
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @file
+ * Install, update and uninstall functions for the dbcdk_community module.
+ */
+
+/**
+ * Implements hook_requirements().
+ */
+function dbcdk_community_requirements($phase) {
+  $requirements = [];
+
+  if ($phase === 'runtime') {
+    // Add a requirement regarding access to community service.
+    $config = Drupal::config('dbcdk_community.settings');
+    $url = $config->get('community_service_url');
+
+    $service_requirement = [
+      'title' => 'DBCDK community service',
+      'value' => $url,
+      'severity' => REQUIREMENT_OK,
+    ];
+
+    /* @var \DBCDK\CommunityServices\Api\ProfileApi $profile_api */
+    $profile_api = Drupal::service('dbcdk_community.api.profile');
+    try {
+      // Try to do an arbitrary call the the community service. Getting an
+      // actual result is not important here.
+      $profile_api->profileFindOne();
+    }
+    catch (\DBCDK\CommunityServices\ApiException $e) {
+      // If an exception is thrown then mark the requirement as failed.
+      $service_requirement['severity'] = REQUIREMENT_ERROR;
+      $service_requirement['description'] = $e->getMessage();
+    }
+
+    $requirements[] = $service_requirement;
+  }
+
+  return $requirements;
+}


### PR DESCRIPTION
When configuration is stored in settings.php it can be hard to see what
config is actually used. This helps a bit.

![status report biblo admin 2016-03-22 15-14-51](https://cloud.githubusercontent.com/assets/73966/13954387/d9266da2-f040-11e5-925a-6f97a25f7428.png)
