### PR TITLE
#497 + #498: Flagged content details

### DIFF
--- a/web/config/sync/page_manager.page.dbcdk_community_flagged_content_details.yml
+++ b/web/config/sync/page_manager.page.dbcdk_community_flagged_content_details.yml
@@ -1,0 +1,24 @@
+uuid: ea509af8-8f0d-4c3f-8901-1bcc8166db5e
+langcode: en
+status: true
+dependencies:
+  module:
+    - ctools
+id: dbcdk_community_flagged_content_details
+label: 'Flagged content details'
+use_admin_theme: null
+path: '/admin/content/dbcdk_community/flagged_content/{flag_id}'
+access_logic: and
+access_conditions:
+  25197eee-10ab-4364-8706-6e121b796a64:
+    id: ctools_user_permission
+    permission: 'dbcdk community moderate content'
+    negate: 0
+    context_mapping:
+      user: current_user
+    uuid: 25197eee-10ab-4364-8706-6e121b796a64
+parameters:
+  flag_id:
+    machine_name: flag_id
+    type: integer
+    label: Flag_id

--- a/web/config/sync/page_manager.page_variant.dbcdk_community_flagged_content_details.yml
+++ b/web/config/sync/page_manager.page_variant.dbcdk_community_flagged_content_details.yml
@@ -1,0 +1,43 @@
+uuid: 2f2b2d90-d69a-464e-9420-32ba68e33aec
+langcode: en
+status: true
+dependencies:
+  config:
+    - page_manager.page.dbcdk_community_flagged_content_details
+  module:
+    - dbcdk_community
+id: dbcdk_community_flagged_content_details
+label: 'Flagged content details'
+variant: block_display
+variant_settings:
+  blocks:
+    6e6e3dcb-71e4-4b76-a145-69384b412b3e:
+      id: flagged_content_details_block
+      label: 'Content details'
+      provider: dbcdk_community
+      label_display: visible
+      region: top
+      weight: 0
+      uuid: 6e6e3dcb-71e4-4b76-a145-69384b412b3e
+      context_mapping:
+        flag_id: flag_id
+    ea398f38-fea4-4261-b700-b7815cfc9b95:
+      id: flagged_content_flag_list_block
+      label: 'Flag list'
+      provider: dbcdk_community
+      label_display: visible
+      region: top
+      weight: 0
+      uuid: ea398f38-fea4-4261-b700-b7815cfc9b95
+      context_mapping:
+        flag_id: flag_id
+  id: block_display
+  label: null
+  uuid: cbe58cc8-d3dd-4021-a30d-130102286c64
+  weight: 0
+  page_title: ''
+page: dbcdk_community_flagged_content_details
+weight: 0
+selection_criteria: {  }
+selection_logic: and
+static_context: {  }

--- a/web/modules/custom/dbcdk_community/src/Content/FlaggableContent.php
+++ b/web/modules/custom/dbcdk_community/src/Content/FlaggableContent.php
@@ -77,7 +77,15 @@ class FlaggableContent {
   public function addFlag(Flag $flag) {
     $this->flags = array_unique(array_merge($this->flags, [$flag]));
     usort($this->flags, function(Flag $a, Flag $b) {
-      return $a->getTimeFlagged()->getTimestamp() - $b->getTimeFlagged()->getTimestamp();
+      $a_timestamp = NULL;
+      $b_timestamp = NULL;
+      if (!empty($a->getTimeFlagged())) {
+        $a_timestamp = $a->getTimeFlagged()->getTimestamp();
+      }
+      if (!empty($b->getTimeFlagged())) {
+        $b_timestamp = $b->getTimeFlagged()->getTimestamp();
+      }
+      return $a_timestamp - $b_timestamp;
     });
     return $this;
   }
@@ -169,6 +177,18 @@ class FlaggableContent {
   public function getLatestFlag() {
     $flags = array_reverse($this->flags);
     return array_shift($flags);
+  }
+
+  /**
+   * Get all unread flags attached to this piece of content.
+   *
+   * @return Flag[]
+   *   All unread flags.
+   */
+  public function getUnreadFlags() {
+    return array_filter($this->flags, function(Flag $flag) {
+      return !$flag->getMarkedAsRead();
+    });
   }
 
 }

--- a/web/modules/custom/dbcdk_community/src/Content/FlaggableContent.php
+++ b/web/modules/custom/dbcdk_community/src/Content/FlaggableContent.php
@@ -75,7 +75,7 @@ class FlaggableContent {
    *   Return the current object.
    */
   public function addFlag(Flag $flag) {
-    $this->flags[] = $flag;
+    $this->flags = array_unique(array_merge($this->flags, [$flag]));
     usort($this->flags, function(Flag $a, Flag $b) {
       return $a->getTimeFlagged()->getTimestamp() - $b->getTimeFlagged()->getTimestamp();
     });

--- a/web/modules/custom/dbcdk_community/src/Content/FlaggableContent.php
+++ b/web/modules/custom/dbcdk_community/src/Content/FlaggableContent.php
@@ -124,6 +124,41 @@ class FlaggableContent {
   }
 
   /**
+   * Get the id of the profile that created this piece of content.
+   *
+   * @see DBCDK\CommunityServices\Api\ProfileApi
+   *
+   * @return int
+   *   The creator profile id.
+   */
+  public function getCreatorId() {
+    $creator_id = NULL;
+    // Creator id is stored in different attributes in the different types of
+    // content classes supported. We use reflection to determine which.
+    $creator_getter = [
+      'getCommentownerid',
+      'getPostownerid',
+    ];
+    foreach ($creator_getter as $getter) {
+      if (method_exists($this->object, $getter)) {
+        $creator_id = $this->object->{$getter}();
+        break;
+      }
+    }
+    return $creator_id;
+  }
+
+  /**
+   * Get the time when the piece of content was created.
+   *
+   * @return \DateTime
+   *   The time when the object was created.
+   */
+  public function getTimeCreated() {
+    return $this->object->getTimeCreated();
+  }
+
+  /**
    * Get the most recent flag attached to this piece of content.
    *
    * Most recent is the time where the flag was created.

--- a/web/modules/custom/dbcdk_community/src/Content/FlaggableContentRepository.php
+++ b/web/modules/custom/dbcdk_community/src/Content/FlaggableContentRepository.php
@@ -109,9 +109,7 @@ class FlaggableContentRepository {
         // individual flag so we try to retrieve information for the
         // remaining flags as well.
         $this->logger->warning($e);
-
-        $posts = [];
-        $comments = [];
+        continue;
       }
       $flagged_content = array_map(function($content) use ($flag) {
         return (new FlaggableContent($content))->addFlag($flag);

--- a/web/modules/custom/dbcdk_community/src/Content/FlaggableContentRepository.php
+++ b/web/modules/custom/dbcdk_community/src/Content/FlaggableContentRepository.php
@@ -161,4 +161,28 @@ class FlaggableContentRepository {
     $content = $this->getContent(['where' => ['id' => $flag_id], 'limit' => 1]);
     return array_shift($content);
   }
+
+  /**
+   * Get a piece of flaggable content and ALL flags attached to a specific flag.
+   *
+   * @param int $flag_id
+   *   The id of the flag for which to retrieve content.
+   *
+   * @return FlaggableContent|NULL
+   *    The content attached to the flag with all other attached flags included
+   *    as well.
+   */
+  public function getContentByIdAllFlags($flag_id) {
+    $flagged_content = $this->getContentById($flag_id);
+    if (!empty($flagged_content)) {
+      $content_all_flags = $this->getContent();
+      foreach ($content_all_flags as $content) {
+        if ($flagged_content->equals($content)) {
+          $flagged_content->addFlags($content->getFlags());
+        }
+      }
+    }
+    return $flagged_content;
+  }
+
 }

--- a/web/modules/custom/dbcdk_community/src/Form/FlagsMarkReadForm.php
+++ b/web/modules/custom/dbcdk_community/src/Form/FlagsMarkReadForm.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * @file
+ * Class definition for FlagsMarkReadForm.
+ */
+
+namespace Drupal\dbcdk_community\Form;
+
+use DBCDK\CommunityServices\Api\FlagApi;
+use DBCDK\CommunityServices\ApiException;
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Form for marking a list of flags.
+ */
+class FlagsMarkReadForm extends FormBase {
+
+  /**
+   * The flag API to use when marking flags as read.
+   *
+   * @var \DBCDK\CommunityServices\Api\FlagApi
+   */
+  protected $flagApi;
+
+  /**
+   * The logger to use.
+   *
+   * @var LoggerInterface
+   */
+  protected $logger;
+
+  /**
+   * FlagsMarkReadForm constructor.
+   *
+   * @param LoggerInterface $logger
+   *   The logger to use.
+   * @param FlagApi $flag_api
+   *   The flag API to use when marking flags as read.
+   */
+  public function __construct(LoggerInterface $logger, FlagApi $flag_api) {
+    $this->flagApi = $flag_api;
+    $this->logger = $logger;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    /* @var \Drupal\Core\Logger\LoggerChannelFactory $logger_factory */
+    $logger_factory = $container->get('logger.factory');
+
+    return new static(
+      $logger_factory->get('DBCDK Community Service'),
+      $container->get('dbcdk_community.api.flag')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'dbcdk_community_flagged_content_mark_all_as_read_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    // We expect one or more flags to be passed as a build argument when getting
+    // the form.
+    $info = $form_state->getBuildInfo();
+    if (!empty($info['args'][0])) {
+      $flags = $info['args'][0];
+      if (!is_array($flags)) {
+        $flags = [$flags];
+      }
+      $form_state->set('flags', $flags);
+    }
+
+    $form['actions']['#type'] = 'actions';
+    $form['actions']['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Mark all flags as read'),
+      '#button_type' => 'primary',
+    ];
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    /* @var \Drupal\dbcdk_community\Content\FlaggableContent $flagged_content */
+    $flags = $form_state->get('flags');
+    if (empty($flags)) {
+      $this->logger->warning('Attempt to mark all flags as read without a valid flaggable content element');
+      return;
+    }
+
+    try {
+      foreach ($flags as $flag) {
+        $flag->setMarkedAsRead(TRUE);
+        $this->flagApi->flagUpsert($flag);
+        drupal_set_message($this->t('Marked flag(s) as read'));
+      }
+    }
+    catch (ApiException $e) {
+      $this->logger($e);
+      drupal_set_message($this->t('An error occurred when trying to mark a flag as read'), 'error');
+    }
+  }
+
+}

--- a/web/modules/custom/dbcdk_community/src/Plugin/Block/FlaggedContentDetailsBlock.php
+++ b/web/modules/custom/dbcdk_community/src/Plugin/Block/FlaggedContentDetailsBlock.php
@@ -1,0 +1,189 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\dbcdk_community\Plugin\Block\FlaggedContentDetails.
+ */
+
+namespace Drupal\dbcdk_community\Plugin\Block;
+
+use DBCDK\CommunityServices\Api\ProfileApi;
+use DBCDK\CommunityServices\ApiException;
+use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Link;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Url;
+use Drupal\dbcdk_community\Url\ModelUrlGenerator;
+use Drupal\dbcdk_community\Url\PropertyUrlGenerator;
+use Drupal\dbcdk_community\Url\UrlGeneratorInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\dbcdk_community\Content\FlaggableContentRepository;
+
+/**
+ * Provides a 'FlaggedContentDetails' block.
+ *
+ * @Block(
+ *  id = "flagged_content_details_block",
+ *  admin_label = @Translation("Flagged content details"),
+ *  context = {
+ *    "flag_id" = @ContextDefinition("integer")
+ *  }
+ * )
+ */
+class FlaggedContentDetailsBlock extends BlockBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The repository to use when retrieving flaggable content.
+   *
+   * @var FlaggableContentRepository
+   */
+  protected $flaggableContentRepository;
+
+  /**
+   * The profile api to use when retrieving information about content owners.
+   *
+   * @var ProfileApi
+   */
+  protected $profileApi;
+
+  /**
+   * The url generator to use when creating links to the biblo.dk site.
+   *
+   * @var UrlGeneratorInterface
+   */
+  protected $urlGenerator;
+
+  /**
+   * The logger to use.
+   *
+   * @var LoggerInterface
+   */
+  protected $logger;
+
+  /**
+   * Construct.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param string $plugin_definition
+   *   The plugin implementation definition.
+   * @param LoggerInterface $logger
+   *   The logger to use.
+   * @param FlaggableContentRepository $repository
+   *   The repository to use when retrieving flaggable content.
+   * @param ProfileApi $profile_api
+   *   The profile api to use when retrieving information about content owners.
+   * @param UrlGeneratorInterface $url_generator
+   *   The url generator to use when generating links to the biblo.dk site.
+   */
+  public function __construct(
+        array $configuration,
+        $plugin_id,
+        $plugin_definition,
+        LoggerInterface $logger,
+        FlaggableContentRepository $repository,
+        ProfileApi $profile_api,
+        UrlGeneratorInterface $url_generator
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->logger = $logger;
+    $this->flaggableContentRepository = $repository;
+    $this->profileApi = $profile_api;
+    $this->urlGenerator = $url_generator;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    /* @var \Drupal\Core\Logger\LoggerChannelFactory $logger_factory */
+    $logger_factory = $container->get('logger.factory');
+
+    // Setup url generation for flaggable content.
+    /* @var \Drupal\Core\Config\Config $config */
+    $config = $container->get('config.factory')->get('dbcdk_community.settings');
+    $base_url = $config->get('community_site_url');
+    $url_generator = new ModelUrlGenerator();
+    $url_generator->registerClassGenerator(
+      'DBCDK\CommunityServices\Model\Post',
+      new PropertyUrlGenerator(
+        $base_url . $config->get('community_site_post_url_pattern')
+      )
+    );
+    $url_generator->registerClassGenerator(
+      'DBCDK\CommunityServices\Model\Comment',
+      new PropertyUrlGenerator(
+        $base_url . $config->get('community_site_comment_url_pattern')
+      )
+    );
+
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $logger_factory->get('DBCDK Community Service'),
+      $container->get('dbcdk_community.content.flaggable_content_repository'),
+      $container->get('dbcdk_community.api.profile'),
+      $url_generator
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    $flag_id = $this->getContextValue('flag_id');
+
+    try {
+      $content = $this->flaggableContentRepository->getContentById($flag_id);
+      $profile = $this->profileApi->profileFindById($content->getCreatorId());
+
+      $profile_link = Link::createFromRoute(
+        $profile->getUsername(),
+        'page_manager.page_view_dbcdk_community_profile',
+        ['username' => $profile->getUsername()]
+      );
+
+      $url = $this->urlGenerator->generate($content->getObject());
+      $content_link = Link::fromTextAndUrl($url, Url::fromUri($url));
+
+      $rows = [
+        [$this->t('Content'), $content->getContent()],
+        [$this->t('Created on'), $content->getTimeCreated()->format('H:i d-m-Y')],
+        [$this->t('Author'), $profile_link],
+        [$this->t('View on biblo.dk'), $content_link],
+      ];
+    }
+    catch (ApiException $e) {
+      // If an error occours then log it and display an empty table.
+      $this->logger->error($e);
+      $rows = [];
+    }
+
+    $table = [
+      '#theme' => 'table',
+      '#header' => [
+        $this->t('Subject'),
+        $this->t('Information'),
+      ],
+      '#rows' => $rows,
+      '#empty' => $this->t('No information found for content related to flag "%flag_id".', [
+        '%flag_id' => $flag_id,
+      ]),
+      '#cache' => [
+        'max-age' => 0,
+      ],
+    ];
+
+    return [
+      'table' => $table,
+      '#cache' => [
+        'max-age' => 0,
+      ],
+    ];
+  }
+
+}

--- a/web/modules/custom/dbcdk_community/src/Plugin/Block/FlaggedContentFlagListBlock.php
+++ b/web/modules/custom/dbcdk_community/src/Plugin/Block/FlaggedContentFlagListBlock.php
@@ -1,0 +1,188 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\dbcdk_community\Plugin\Block\FlaggedContentFlagList.
+ */
+
+namespace Drupal\dbcdk_community\Plugin\Block;
+
+use DBCDK\CommunityServices\ApiException;
+use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Form\FormBuilder;
+use Drupal\Core\Link;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\dbcdk_community\Content\FlaggableContentRepository;
+use DBCDK\CommunityServices\Api\ProfileApi;
+
+/**
+ * Provides a 'FlaggedContentFlagList' block.
+ *
+ * @Block(
+ *  id = "flagged_content_flag_list_block",
+ *  admin_label = @Translation("Flagged content flag list"),
+ *  context = {
+ *    "flag_id" = @ContextDefinition("integer")
+ *  }
+ * )
+ */
+class FlaggedContentFlagListBlock extends BlockBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The repository to use for retrieving flaggable content to show in the list.
+   *
+   * @var FlaggableContentRepository
+   */
+  protected $flaggableContentRepository;
+
+  /**
+   * The profile api to use for retrieving information about content owners.
+   *
+   * @var ProfileApi
+   */
+  protected $profileApi;
+
+  /**
+   * The form builder to use to allow users to interact with flags.
+   *
+   * @var FormBuilder
+   */
+  protected $formBuilder;
+
+  /**
+   * The logger to use.
+   *
+   * @var LoggerInterface
+   */
+  protected $logger;
+
+  /**
+   * Construct.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param string $plugin_definition
+   *   The plugin implementation definition.
+   * @param LoggerInterface $logger
+   *   The logger to use.
+   * @param FlaggableContentRepository $repository
+   *   The repository to use.
+   * @param ProfileApi $profile_api
+   *   The profile api to use.
+   * @param FormBuilder $form_builder
+   *   The form builder to use.
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    LoggerInterface $logger,
+    FlaggableContentRepository $repository,
+    ProfileApi $profile_api,
+    FormBuilder $form_builder
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->logger = $logger;
+    $this->flaggableContentRepository = $repository;
+    $this->profileApi = $profile_api;
+    $this->formBuilder = $form_builder;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    /* @var \Drupal\Core\Logger\LoggerChannelFactory $logger_factory */
+    $logger_factory = $container->get('logger.factory');
+
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $logger_factory->get('DBCDK Community Service'),
+      $container->get('dbcdk_community.content.flaggable_content_repository'),
+      $container->get('dbcdk_community.api.profile'),
+      $container->get('form_builder')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    $flag_id = $this->getContextValue('flag_id');
+
+    try {
+      /* @var \Drupal\dbcdk_community\Content\FlaggableContent $content */
+      $content = $this->flaggableContentRepository->getContentByIdAllFlags($flag_id);
+      $flags = $content->getFlags();
+      $unread_flags = $content->getUnreadFlags();
+    }
+    catch (ApiException $e) {
+      // If the API fails then provide a dummy piece of content with no flags.
+      // The display should handle the rest.
+      $this->logger->error($e);
+      $flags = [];
+      $unread_flags = [];
+    }
+
+    $table = [
+      '#theme' => 'table',
+      '#header' => [
+        $this->t('Time flagged'),
+        $this->t('Description'),
+        $this->t('Flagged by'),
+        $this->t('Read'),
+      ],
+      '#rows' => [],
+      '#empty' => $this->t('No flags found for this piece of content.'),
+    ];
+
+    foreach (array_reverse($flags) as $flag) {
+      /* @var \DBCDK\CommunityServices\Model\Flag $flag */
+
+      try {
+        $profile = $this->profileApi->profileFindById($flag->getOwnerId());
+        $profile_string = Link::createFromRoute(
+          $profile->getUsername(),
+          'page_manager.page_view_dbcdk_community_profile',
+          ['username' => $profile->getUsername()]
+        );
+      }
+      catch (ApiException $e) {
+        // If we are unable to get the profile then display the profile id.
+        $profile_string = $this->t(
+          'Profile %id',
+          ['%id' => $flag->getOwnerId()]
+        );
+        $this->logger->error($e);
+      }
+
+      $table['#rows'][] = [
+        $flag->getTimeFlagged()->format('Y-m-d H:i'),
+        $flag->getDescription(),
+        $profile_string,
+        $flag->getMarkedAsRead() ? $this->t('Yes') : $this->t('No'),
+      ];
+    }
+
+    // If there are  any unread flags then support marking them all as read.
+    $form = NULL;
+    if (!empty($unread_flags)) {
+      $form = $this->formBuilder->getForm('Drupal\dbcdk_community\Form\FlagsMarkReadForm', $unread_flags);
+    }
+
+    return [
+      'table' => $table,
+      'form' => $form,
+      '#cache' => [
+        'max-age' => 0,
+      ],
+    ];
+  }
+
+}

--- a/web/modules/custom/dbcdk_community/src/Plugin/Block/FlaggedContentList.php
+++ b/web/modules/custom/dbcdk_community/src/Plugin/Block/FlaggedContentList.php
@@ -12,7 +12,6 @@ use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Link;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Url;
-use Drupal\Core\Utility\LinkGeneratorInterface;
 use Drupal\dbcdk_community\Content\FlaggableContentRepository;
 use Drupal\dbcdk_community\Url\ModelUrlGenerator;
 use Drupal\dbcdk_community\Url\PropertyUrlGenerator;
@@ -149,6 +148,7 @@ class FlaggedContentList extends BlockBase implements ContainerFactoryPluginInte
         $this->t('Active flags'),
         $this->t('Latest flag'),
         $this->t('Flag comment'),
+        $this->t('Details'),
         $this->t('Link'),
       ],
       '#data' => [],
@@ -167,10 +167,18 @@ class FlaggedContentList extends BlockBase implements ContainerFactoryPluginInte
           $this->t('View on Biblo.dk'),
           $community_site_url
         );
+
+        $details_link = Link::createFromRoute(
+          $this->t('See details'),
+          'page_manager.page_view_dbcdk_community_flagged_content_details',
+          ['flag_id' => $content_element->getLatestFlag()->getId()]
+        );
       }
       catch (\Exception $e) {
-        // If generating a link fails then do not output anything.
+        // If generating a link fails then do not output any links.
         $this->logger->warning($e);
+
+        $details_link = '';
         $community_site_link = '';
       }
 
@@ -179,6 +187,7 @@ class FlaggedContentList extends BlockBase implements ContainerFactoryPluginInte
         count($content_element->getFlags()),
         $content_element->getLatestFlag()->getTimeFlagged()->format('Y-m-d H:i'),
         $content_element->getLatestFlag()->getDescription(),
+        $details_link,
         $community_site_link,
       ];
     }

--- a/web/modules/custom/dbcdk_community/tests/src/Unit/Content/FlaggableContentRepositoryTest.php
+++ b/web/modules/custom/dbcdk_community/tests/src/Unit/Content/FlaggableContentRepositoryTest.php
@@ -23,6 +23,34 @@ use Drupal\Tests\UnitTestCase;
 class FlaggableContentRepositoryTest extends UnitTestCase {
 
   /**
+   * Test that flaggable content can be retrieved by id.
+   *
+   * @param Flag[] $flags
+   *   The flags to return from the Flag API in the test.
+   * @param Post[] $flag_post_map
+   *   A map of flag ids to posts in the test.
+   * @param Comment[] $flag_comment_map
+   *   A map of flag ids to comments in the test.
+   *
+   * @dataProvider unreadWithFlagsDataProvider
+   */
+  public function testContentById(array $flags, array $flag_post_map, array $flag_comment_map) {
+    // Create a stub flag api using the model.
+    $flag_api_stub = $this->getMock('DBCDK\CommunityServices\Api\FlagApi');
+    $flag_api_stub->method('flagFind')->willReturn(array_slice($flags, 0, 1));
+    $flag_api_stub->method('flagPrototypeGetPosts')->will($this->returnCallback(function($id) use($flag_post_map) {
+      return (!empty($flag_post_map[$id])) ? [$flag_post_map[$id]] : [];
+    }));
+    $flag_api_stub->method('flagPrototypeGetComments')->will($this->returnCallback(function($id) use ($flag_comment_map) {
+      return (!empty($flag_comment_map[$id])) ? [$flag_comment_map[$id]] : [];
+    }));
+
+    $repo = new FlaggableContentRepository($flag_api_stub);
+    $flaggable_content = $repo->getContentById(1);
+    $this->assertTrue($flaggable_content->equals(new FlaggableContent($flag_post_map[1])));
+  }
+
+  /**
    * Test that we can assemble a list of content with flags.
    *
    * @param Flag[] $flags
@@ -39,10 +67,10 @@ class FlaggableContentRepositoryTest extends UnitTestCase {
     $flag_api_stub = $this->getMock('DBCDK\CommunityServices\Api\FlagApi');
     $flag_api_stub->method('flagFind')->willReturn($flags);
     $flag_api_stub->method('flagPrototypeGetPosts')->will($this->returnCallback(function($id) use($flag_post_map) {
-      return (!empty($flag_post_map[$id])) ? $flag_post_map[$id] : [];
+      return (!empty($flag_post_map[$id])) ? [$flag_post_map[$id]] : [];
     }));
     $flag_api_stub->method('flagPrototypeGetComments')->will($this->returnCallback(function($id) use ($flag_comment_map) {
-      return (!empty($flag_comment_map[$id])) ? $flag_comment_map[$id] : [];
+      return (!empty($flag_comment_map[$id])) ? [$flag_comment_map[$id]] : [];
     }));
 
     $repo = new FlaggableContentRepository($flag_api_stub);
@@ -54,12 +82,12 @@ class FlaggableContentRepositoryTest extends UnitTestCase {
     $this->assertCount(2, $flaggable_content);
 
     // The first flaggable content should be the post and have two flags.
-    $flaggable_post = new FlaggableContent($flag_post_map[1][0]);
+    $flaggable_post = new FlaggableContent($flag_post_map[1]);
     $flaggable_post->addFlags(array_slice($flags, 0, 2));
     $this->assertEquals($flaggable_post, $flaggable_content[0]);
 
     // The second flaggable content should be the comment and have one flag.
-    $flaggable_comment = new FlaggableContent($flag_comment_map[3][0]);
+    $flaggable_comment = new FlaggableContent($flag_comment_map[3]);
     $flaggable_comment->addFlag($flags[2]);
     $this->assertEquals($flaggable_comment, $flaggable_content[1]);
   }
@@ -81,17 +109,17 @@ class FlaggableContentRepositoryTest extends UnitTestCase {
     $post = (new Post())->setId(1);
     $unflagged_post = (new Post())->setId(2);
     $flag_post_map = [
-      0 => [$unflagged_post],
-      1 => [$post],
-      2 => [$post],
+      0 => $unflagged_post,
+      1 => $post,
+      2 => $post,
     ];
 
     // This comment should have a single flag.
     $comment = (new Comment())->setId(1);
     $unflagged_comment = (new Comment())->setId(2);
     $flag_comment_map = [
-      3 => [$comment],
-      4 => [$unflagged_comment],
+      3 => $comment,
+      4 => $unflagged_comment,
     ];
 
     return [

--- a/web/modules/custom/dbcdk_community/tests/src/Unit/Content/FlaggableContentTest.php
+++ b/web/modules/custom/dbcdk_community/tests/src/Unit/Content/FlaggableContentTest.php
@@ -65,4 +65,23 @@ class FlaggableContentTest extends UnitTestCase {
     $this->assertEquals($flag_now, $flaggable->getLatestFlag());
   }
 
+  /**
+   * Test that unread flags can be retrieved.
+   */
+  public function testUnreadFlags() {
+    $flaggable = new FlaggableContent(new Comment());
+
+    $flag_unread = (new Flag())
+      ->setId(1)
+      ->setMarkedAsRead(FALSE);
+    $flag_read = (new Flag())
+      ->setId(2)
+      ->setMarkedAsRead(TRUE);
+
+    $flaggable->addFlag($flag_unread)->addFlag($flag_read);
+
+    $this->assertCount(1, $flaggable->getUnreadFlags());
+    $this->assertContains($flag_unread, $flaggable->getUnreadFlags());
+  }
+
 }


### PR DESCRIPTION
This pull request adds a page manager page displaying details about a flagged piece of content:
- Content details
- List of all flags belonging to that content
- The option of marking all the flags as read
