### PR TITLE
Optimize flagged content caption

### DIFF
--- a/web/modules/custom/dbcdk_community/src/Plugin/Block/FlaggedContentList.php
+++ b/web/modules/custom/dbcdk_community/src/Plugin/Block/FlaggedContentList.php
@@ -81,14 +81,19 @@ class FlaggedContentList extends BlockBase implements ContainerFactoryPluginInte
     $content_per_page = 10;
     $page = pager_default_initialize(count($all_content_elements), $content_per_page);
 
+    $caption = '';
+    if (count($all_content_elements) > $content_per_page) {
+      $caption = $this->t(
+        'Showing %from-%to of %total pieces of flagged content', [
+        '%from' => ($page * $content_per_page) + 1,
+        '%to' => ($page + 1) * $content_per_page,
+        '%total' => count($all_content_elements),
+      ]);
+    }
+    
     $table = [
       '#theme' => 'table',
-      '#caption' => $this->t(
-        'Showing %from-%to of %total pieces of flagged content', [
-          '%from' => ($page * $content_per_page) + 1,
-          '%to' => ($page + 1) * $content_per_page,
-          '%total' => count($all_content_elements),
-        ]),
+      '#caption' => $caption,
       '#header' => [
         $this->t('Content'),
         $this->t('Active flags'),

--- a/web/modules/custom/dbcdk_community/src/Plugin/Block/FlaggedContentList.php
+++ b/web/modules/custom/dbcdk_community/src/Plugin/Block/FlaggedContentList.php
@@ -86,7 +86,7 @@ class FlaggedContentList extends BlockBase implements ContainerFactoryPluginInte
       $caption = $this->t(
         'Showing %from-%to of %total pieces of flagged content', [
         '%from' => ($page * $content_per_page) + 1,
-        '%to' => ($page + 1) * $content_per_page,
+        '%to' => min((($page + 1) * $content_per_page), count($all_content_elements)),
         '%total' => count($all_content_elements),
       ]);
     }


### PR DESCRIPTION
This ensures that the caption for the flag list is only shown if it is needed. It displays paging information and is irrelevant if there are no pages.
