### PR TITLE
Correct flagged content label

### DIFF
--- a/web/config/sync/page_manager.page_variant.dbcdk_community_flagged_content.yml
+++ b/web/config/sync/page_manager.page_variant.dbcdk_community_flagged_content.yml
@@ -7,7 +7,7 @@ dependencies:
   module:
     - dbcdk_community
 id: dbcdk_community_flagged_content
-label: Flagged content
+label: 'Flagged content'
 variant: block_display
 variant_settings:
   blocks:


### PR DESCRIPTION
Drupal's CMI wants single quotations around sentences and no quotation around single words.

This change will stop CMI's export to say the file is overridden.
