### PR TITLE
Update permissions for Drupal users

### DIFF
--- a/web/config/sync/user.role.admin_moderator.yml
+++ b/web/config/sync/user.role.admin_moderator.yml
@@ -8,3 +8,13 @@ weight: 3
 is_admin: null
 permissions:
   - 'moderate content'
+  - 'dbcdk community moderate content'
+  - 'dbcdk community moderate profiles'
+  - 'use text format dbcdk_community_basic_markup'
+  - 'access content overview'
+  - 'administer nodes'
+  - 'delete all revisions'
+  - 'revert all revisions'
+  - 'view all revisions'
+  - 'access administration pages'
+  - 'view the administration theme'

--- a/web/config/sync/user.role.authenticated.yml
+++ b/web/config/sync/user.role.authenticated.yml
@@ -10,3 +10,7 @@ weight: 1
 is_admin: false
 permissions:
   - 'access content'
+  - 'access content overview'
+  - 'view own unpublished content'
+  - 'access site reports'
+  - 'access toolbar'


### PR DESCRIPTION
These changes will allow Admin Moderators to access the community service features and authenticated users to have basic access.
