### PR TITLE
Refactor "Edit Profile" form

### DIFF
--- a/web/modules/custom/dbcdk_community/src/Form/ProfileEditForm.php
+++ b/web/modules/custom/dbcdk_community/src/Form/ProfileEditForm.php
@@ -10,21 +10,17 @@ namespace Drupal\dbcdk_community\Form;
 use DBCDK\CommunityServices\ApiException;
 use DBCDK\CommunityServices\Api\ProfileApi;
 use DBCDK\CommunityServices\Model\Profile;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Edit a Community Service Profile.
  */
 class ProfileEditForm extends FormBase implements ContainerInjectionInterface {
-
-  /**
-   * The date format the Community Client expects.
-   */
-  const DATE_FORMAT = 'Y-m-d';
 
   /**
    * The DBCDK Community Service Profile API.
@@ -50,14 +46,14 @@ class ProfileEditForm extends FormBase implements ContainerInjectionInterface {
   /**
    * Creates a Profile Edit Form instance.
    *
+   * @param \DBCDK\CommunityServices\Api\ProfileApi $profile_api
+   *   The DBCDK Community Service Profile API.
    * @param \DBCDK\CommunityServices\Model\Profile $profile
    *   The DBCDK Community Profile object we wish to edit.
    * @param \DBCDK\CommunityServices\Model\CommunityRole[] $community_roles
    *   Results array with all possible Community Roles.
-   * @param \DBCDK\CommunityServices\Api\ProfileApi $profile_api
-   *   The DBCDK Community Service Profile API.
    */
-  public function __construct(Profile $profile, array $community_roles, ProfileApi $profile_api) {
+  public function __construct(ProfileApi $profile_api, Profile $profile = NULL, array $community_roles = []) {
     $this->profileApi = $profile_api;
     $this->communityRoles = $community_roles;
     $this->profile = $profile;
@@ -77,7 +73,7 @@ class ProfileEditForm extends FormBase implements ContainerInjectionInterface {
           'username' => $container->get('request_stack')->getCurrentRequest()->get('username'),
         ],
       ];
-      /* @var \DBCDK\CommunityServices\Model\Profile[] $profile */
+      /* @var \DBCDK\CommunityServices\Model\Profile $profile */
       $profile = $profile_api->profileFindOne(json_encode($filter));
       // The Swagger-compiled Community Profile Model does not support Community
       // Roles when using "include" to get the profile. The response from the
@@ -92,14 +88,14 @@ class ProfileEditForm extends FormBase implements ContainerInjectionInterface {
     }
     catch (ApiException $e) {
       \Drupal::logger('DBCDK Community Service')->error($e);
-      $profile = [];
+      $profile = NULL;
       $community_roles = [];
     }
 
     return new static(
+      $profile_api,
       $profile,
-      $community_roles,
-      $profile_api
+      $community_roles
     );
   }
 
@@ -113,7 +109,7 @@ class ProfileEditForm extends FormBase implements ContainerInjectionInterface {
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state, $username = NULL) {
+  public function buildForm(array $form, FormStateInterface $form_state) {
     // Defensive coding to make sure we only display the actual edit form if
     // the service could find a Community Profile.
     if (empty($this->profile)) {
@@ -153,10 +149,10 @@ class ProfileEditForm extends FormBase implements ContainerInjectionInterface {
     ];
 
     $form['birthday'] = [
-      '#type' => 'date',
+      '#type' => 'datetime',
       '#title' => $this->t('Birthday'),
-      '#default_value' => $this->profile->getBirthday()->format(self::DATE_FORMAT),
-      '#date_date_format' => self::DATE_FORMAT,
+      '#date_time_element' => 'none',
+      '#default_value' => DrupalDateTime::createFromDateTime($this->profile->getBirthday()),
     ];
 
     $form['roles'] = [
@@ -187,7 +183,7 @@ class ProfileEditForm extends FormBase implements ContainerInjectionInterface {
       '#type' => 'link',
       '#title' => $this->t('Cancel'),
       '#url' => new Url('page_manager.page_view_dbcdk_community_profile', [
-        'username' => $username,
+        'username' => $this->profile->getUsername(),
       ]),
       '#attributes' => ['class' => ['button']],
     ];
@@ -210,14 +206,14 @@ class ProfileEditForm extends FormBase implements ContainerInjectionInterface {
         'birthday',
         'description',
       ];
-      $profile_fields = $this->updateProfileFields($fields, $form_state);
+      $this->updateProfileFields($fields, $form_state);
 
       // Update roles based on the submitted "roles" input.
       // The array returned from a checkbox field includes both selected and
       // unselected elements so we have to filter away any elements that are
       // considered false.
       $role_ids = array_filter($form_state->getValue('roles'));
-      $profile_roles = $this->updateProfileRoles($role_ids);
+      $this->updateProfileRoles($role_ids);
     }
     catch (ApiException $e) {
       \Drupal::logger('DBCDK Community Service')->error($e);
@@ -225,105 +221,69 @@ class ProfileEditForm extends FormBase implements ContainerInjectionInterface {
       return FALSE;
     }
 
-    // If any of the profile updated above returned TRUE then we provide a
-    // success message for the moderator and redirect to the profile page.
-    if ($profile_fields || $profile_roles) {
-      drupal_set_message($this->t('The profile "%profile" has been updated.', ['%profile' => $this->profile->getUsername()]));
-      $form_state->setRedirect('page_manager.page_view_dbcdk_community_profile', [
-        'username' => $this->profile->getUsername(),
-      ]);
-    }
-    // If none of the update function above found any changes, then we return
-    // a message for the user that they unsuccessfully tried to submit data
-    // without changing anything.
-    else {
-      drupal_set_message(
-        $this->t('There were no changes detected for the profile "%profile".', ['%profile' => $this->profile->getUsername()]),
-        'warning'
-      );
-    }
+    drupal_set_message($this->t('The profile "%profile" has been updated.', ['%profile' => $this->profile->getUsername()]));
+    $form_state->setRedirect('page_manager.page_view_dbcdk_community_profile', [
+      'username' => $this->profile->getUsername(),
+    ]);
   }
 
   /**
    * Update Community Profile Fields.
    *
-   * Go through each field anc check if there is any differences from the
-   * original value and the new value. If there is, then we add it to an array
-   * of new data. - We do this to make sure we actually have to PUT any data to
-   * the Community Service and return a "state" so the submitForm() method can
-   * provide different messages for the moderator depending on what happened.
+   * Go through each provided field on a Profile (some requires special
+   * handling) and set the new value. We then update the Profile when the
+   * iteration is done.
    *
    * @param array $fields
-   *   Array of fields to compare and update on the Community Profile.
+   *   Array of fields to update on the Community Profile.
    * @param \Drupal\Core\Form\FormStateInterface $form_state
-   *   The current state of the form.
+   *   The current state from the form.
    *
    * @throws \DBCDK\CommunityServices\ApiException
    *   Throws API Exception if the profile could not be updated.
    *
-   * @return bool
-   *   Returns TRUE if there were any changes to update and vise versa.
+   * @return \DBCDK\CommunityServices\Model\Profile
+   *   The updated Community Service Profile.
    */
   protected function updateProfileFields(array $fields, FormStateInterface $form_state) {
-    $new_data = [];
     foreach ($fields as $field) {
-      // Get the old and new value. This will be used to check if there were
-      // any changes and will of cause also be used in the body of the request.
       $getter = 'get' . ucfirst($field);
-      if (method_exists($this->profile, $getter)) {
-        $old_value = $this->profile->{$getter}();
-        $new_value = $form_state->getValue($field);
-
+      $setter = 'set' . ucfirst($field);
+      if (method_exists($this->profile, $getter) && method_exists($this->profile, $setter)) {
+        $value = $form_state->getValue($field);
         switch ($field) {
-          // The birthday field's original value is a DateTime object so we have
-          // to get the same format as the string the date-field returns to
-          // check if there is any differences.
           case 'birthday':
-            if ($old_value->format(self::DATE_FORMAT) !== $new_value) {
-              $new_data[$field] = $new_value;
-            }
+            $date = new \DateTime();
+            $date = $date->setTimestamp($value->getTimestamp());
+            $this->profile->{$setter}($date);
             break;
 
           default:
-            if ($old_value !== $new_value) {
-              $new_data[$field] = $new_value;
-            }
+            $this->profile->{$setter}($value);
             break;
         }
       }
     }
 
-    if (!empty($new_data)) {
-      // The Community Service needs to know who is being altered, so we have
-      // to set the profiles ID to the body of the PUT request.
-      $new_data['id'] = $this->profile->getId();
-      $this->profile = $this->profileApi->profileUpsert(json_encode($new_data));
-      return TRUE;
-    }
-    else {
-      return FALSE;
-    }
+    return $this->profileApi->profileUpsert($this->profile);
   }
 
   /**
    * Update a Community Profile's roles.
    *
-   * Find out if we have to remove or add any roles from a Community Service
-   * based on values from $form_state and the current Community Profile's roles
-   * and return a boolean representing if anything were updated or not.
+   * Find out if we have to remove or add any roles from a Community Profile
+   * based on values from $form_state and the current Community Profile's roles.
    *
    * @param array $new_role_ids
    *   An array of new role ids.
    *
    * @throws \DBCDK\CommunityServices\ApiException
    *   Throws API Exception if the roles could not be added/removed.
-   *
-   * @return bool
-   *   Returns TRUE if there were any changes to update and vise versa.
    */
   protected function updateProfileRoles(array $new_role_ids) {
     // Format an array of the profile's role ids before any update has happened.
     $old_role_ids = array_map(function($role) {
+      /* @var \DBCDK\CommunityServices\Model\CommunityRole $role */
       return $role->getId();
     }, $this->profile->communityRoles);
 
@@ -342,13 +302,6 @@ class ProfileEditForm extends FormBase implements ContainerInjectionInterface {
         $this->profileApi->profilePrototypeUnlinkCommunityRoles($role, $this->profile->getId());
       }
     };
-
-    if (empty($add_roles) && empty($remove_roles)) {
-      return FALSE;
-    }
-    else {
-      return TRUE;
-    }
   }
 
 }

--- a/web/modules/custom/dbcdk_community/src/Form/ProfileEditForm.php
+++ b/web/modules/custom/dbcdk_community/src/Form/ProfileEditForm.php
@@ -9,6 +9,7 @@ namespace Drupal\dbcdk_community\Form;
 
 use DBCDK\CommunityServices\ApiException;
 use DBCDK\CommunityServices\Api\ProfileApi;
+use DBCDK\CommunityServices\Model\CommunityRole;
 use DBCDK\CommunityServices\Model\Profile;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
@@ -282,8 +283,7 @@ class ProfileEditForm extends FormBase implements ContainerInjectionInterface {
    */
   protected function updateProfileRoles(array $new_role_ids) {
     // Format an array of the profile's role ids before any update has happened.
-    $old_role_ids = array_map(function($role) {
-      /* @var \DBCDK\CommunityServices\Model\CommunityRole $role */
+    $old_role_ids = array_map(function(CommunityRole $role) {
       return $role->getId();
     }, $this->profile->communityRoles);
 


### PR DESCRIPTION
- Handle dates by using \DateTime().
- Allow for NULL values for $profile in the constructor.
- Remove the complexity of checking if there have been made changes to any values.
- Pass the Profile model instead of an array of data when updating a profile.
