### PR TITLE
Use development settings in Docker environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 /web/sites/default/files/
 /web/sites/default/services.yml
 /web/sites/default/settings.php
+/web/sites/default/settings.local.php
 
 # Ignore contrib modules.
 /web/modules/contrib

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ web:
     - './tests:/var/www/tests'
     - './docker/docker.settings.php:/var/www/html/sites/default/settings.php:ro'
     - './docker/docker.services.yml:/var/www/html/sites/default/services.yml:ro'
+    - './docker/docker.settings.local.php:/var/www/html/sites/default/settings.local.php:ro'
+    - './docker/docker.development.services.yml:/var/www/html/sites/development.services.yml:ro'
   working_dir: '/var/www/web'
   links:
     - db

--- a/docker/docker.development.services.yml
+++ b/docker/docker.development.services.yml
@@ -1,0 +1,7 @@
+# Local development services.
+#
+# To activate this feature, follow the instructions at the top of the
+# 'example.settings.local.php' file, which sits next to this file.
+services:
+  cache.backend.null:
+    class: Drupal\Core\Cache\NullBackendFactory

--- a/docker/docker.settings.local.php
+++ b/docker/docker.settings.local.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * Content of example.settings.local.php.
+ */
+
+// Assertions.
+assert_options(ASSERT_ACTIVE, TRUE);
+\Drupal\Component\Assertion\Handle::register();
+
+// Enable local development services.
+$settings['container_yamls'][] = DRUPAL_ROOT . '/sites/development.services.yml';
+
+// Show all error messages, with backtrace information.
+$config['system.logging']['error_level'] = 'verbose';
+
+// Disable CSS and JS aggregation.
+$config['system.performance']['css']['preprocess'] = FALSE;
+$config['system.performance']['js']['preprocess'] = FALSE;
+
+// Disable the render cache (this includes the page cache).
+# $settings['cache']['bins']['render'] = 'cache.backend.null';
+
+// Disable Dynamic Page Cache.
+# $settings['cache']['bins']['dynamic_page_cache'] = 'cache.backend.null';
+
+// Allow test modules and themes to be installed.
+$settings['extension_discovery_scan_tests'] = TRUE;
+
+// Enable access to rebuild.php.
+$settings['rebuild_access'] = TRUE;
+
+/**
+ * Site specific development settings.
+ */
+// Use Docker community service.
+$config['dbcdk_community.settings']['community_service_url'] = 'http://service:3000/api';
+// This site does not exist but we provide one to generate urls.
+$config['dbcdk_community.settings']['community_site_url'] = 'http://dummy.biblo.dk';

--- a/docker/docker.settings.php
+++ b/docker/docker.settings.php
@@ -18,3 +18,7 @@ $settings['update_free_access'] = FALSE;
 $settings['container_yamls'][] = __DIR__ . '/services.yml';
 
 $settings['install_profile'] = 'minimal';
+
+if (file_exists(__DIR__ . '/settings.local.php')) {
+  include __DIR__ . '/settings.local.php';
+}


### PR DESCRIPTION
We use Docker for development. We could/should automatically configure
the Drupal environment accordingly.
