### PR TITLE
Run automated cron every 24 hours

### DIFF
--- a/web/config/sync/automated_cron.settings.yml
+++ b/web/config/sync/automated_cron.settings.yml
@@ -1,0 +1,3 @@
+interval: 86400
+_core:
+  default_config_hash: fUksROt4FfkAU9BV4hV2XvhTBSS2nTNrZS4U7S-tKrs

--- a/web/config/sync/core.extension.yml
+++ b/web/config/sync/core.extension.yml
@@ -1,4 +1,5 @@
 module:
+  automated_cron: 0
   basic_auth: 0
   block: 0
   breakpoint: 0


### PR DESCRIPTION
Using automated cron we do not have to care about cron settings in the
environments. We should not have any heavy cron processing anyway.
