### PR TITLE
Defensive date coding on profiles

### DIFF
--- a/web/modules/custom/dbcdk_community/src/Form/ProfileEditForm.php
+++ b/web/modules/custom/dbcdk_community/src/Form/ProfileEditForm.php
@@ -153,7 +153,9 @@ class ProfileEditForm extends FormBase implements ContainerInjectionInterface {
       '#type' => 'datetime',
       '#title' => $this->t('Birthday'),
       '#date_time_element' => 'none',
-      '#default_value' => DrupalDateTime::createFromDateTime($this->profile->getBirthday()),
+      // Make sure the date is a DateTime object before we try to use it as one.
+      // We do this to avoid fatal errors.
+      '#default_value' => ($this->profile->getBirthday() instanceof \DateTime) ? DrupalDateTime::createFromDateTime($this->profile->getBirthday()) : NULL,
     ];
 
     $form['roles'] = [
@@ -254,9 +256,13 @@ class ProfileEditForm extends FormBase implements ContainerInjectionInterface {
         $value = $form_state->getValue($field);
         switch ($field) {
           case 'birthday':
-            $date = new \DateTime();
-            $date = $date->setTimestamp($value->getTimestamp());
-            $this->profile->{$setter}($date);
+            // Make sure the date is a DrupalDateTime object before we try to
+            // use it as one. We do this to avoid fatal errors.
+            if ($value instanceof DrupalDateTime) {
+              $date = new \DateTime();
+              $date = $date->setTimestamp($value->getTimestamp());
+              $this->profile->{$setter}($date);
+            }
             break;
 
           default:

--- a/web/modules/custom/dbcdk_community/src/Plugin/Block/ProfileBlock.php
+++ b/web/modules/custom/dbcdk_community/src/Plugin/Block/ProfileBlock.php
@@ -157,8 +157,15 @@ class ProfileBlock extends BlockBase implements ContainerFactoryPluginInterface 
         // The birthday field returns a DateTime object and should be formatted
         // with a Drupal Date Format instead.
         case 'birthday':
-          $date_formatter = \Drupal::service('date.formatter');
-          $value = $date_formatter->format($profile->getBirthday()->getTimestamp(), 'dbcdk_community_service_date');
+          // Make sure the date is a DateTime object before we try to use it as
+          // one. We do this to avoid fatal errors.
+          if ($profile->getBirthday() instanceof \DateTime) {
+            $date_formatter = \Drupal::service('date.formatter');
+            $value = $date_formatter->format($profile->getBirthday()->getTimestamp(), 'dbcdk_community_service_date');
+          }
+          else {
+            $value = '';
+          }
           break;
 
         // We have to allow HTML in the output of the description field since


### PR DESCRIPTION
Make sure DateTime/DrupalDateTime objects are objects before usage to avoid fatal errors.
