### PR TITLE
Report code coverage for tests

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -12,12 +12,25 @@ tools:
       standard: Drupal
   eslint:
     use_native_config: true
+
+build:
+  environment:
+    php: '5.6.16'
+    node: 'v4.2.2'
+  dependencies:
+    after:
+      - 'npm install -g eslint'
+  tests:
+    override:
+      -
+        command: 'composer phpunit-custom-clover'
+        coverage:
+          file: 'tests/reports/clover.xml'
+          format: 'php-clover'
+
 build_failure_conditions:
   # No new issues allowed.
   - 'issues.new.exists'
-before_commands:
-  # Install an up-to-date eslint.
-  - 'npm install -g eslint'
 
 filter:
     paths:

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,8 @@
         "phpcs": "vendor/bin/phpcs --standard=vendor/drupal/coder/coder_sniffer/Drupal/ruleset.xml --extensions='php,module,inc,install,test,profile,theme,js,css,info,txt' web/modules/custom",
         "phpcs-checkstyle": "vendor/bin/phpcs --standard=vendor/drupal/coder/coder_sniffer/Drupal/ruleset.xml --extensions='php,module,inc,install,test,profile,theme,js,css,info,txt' web/modules/custom --report=checkstyle --report-file=tests/reports/phpcs-checkstyle.xml",
         "phpunit-drupal": "vendor/bin/phpunit -c web/core/phpunit.xml.dist --testsuite unit --exclude-group Composer --log-junit tests/reports/phpunit-drupal.xml",
-        "phpunit-custom": "vendor/bin/phpunit -c web/core/phpunit.xml.dist --testsuite unit --group dbcdk_community --log-junit tests/reports/phpunit-custom.xml",
+        "phpunit-custom": "vendor/bin/phpunit -c tests/phpunit.xml.dist --testsuite unit --group dbcdk_community --log-junit tests/reports/phpunit-custom.xml --coverage-text",
+        "phpunit-custom-clover": "vendor/bin/phpunit -c tests/phpunit.xml.dist --testsuite unit --group dbcdk_community --log-junit tests/reports/phpunit-custom.xml --coverage-clover=tests/reports/clover.xml",
         "behat": "vendor/bin/behat -c tests/behat.yml",
         "docker-behat": "docker-compose run web ../vendor/bin/behat -c ../tests/behat.yml --profile docker"
     },

--- a/tests/phpunit.xml.dist
+++ b/tests/phpunit.xml.dist
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- TODO set checkForUnintentionallyCoveredCode="true" once https://www.drupal.org/node/2626832 is resolved. -->
+<phpunit bootstrap="../web/core/tests/bootstrap.php" colors="true"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutChangesToGlobalState="true"
+         checkForUnintentionallyCoveredCode="false">
+    <php>
+        <!-- Set error reporting to E_ALL. -->
+        <ini name="error_reporting" value="32767"/>
+        <!-- Do not limit the amount of memory tests take to run. -->
+        <ini name="memory_limit" value="-1"/>
+        <env name="SIMPLETEST_BASE_URL" value=""/>
+        <!-- Example SIMPLETEST_BASE_URL value: http://localhost -->
+        <env name="SIMPLETEST_DB" value=""/>
+        <!-- Example SIMPLETEST_DB value: mysql://username:password@localhost/databasename#table_prefix -->
+    </php>
+    <testsuites>
+        <testsuite name="unit">
+            <directory>../web/modules/custom</directory>
+        </testsuite>
+    </testsuites>
+    <listeners>
+        <listener class="\Drupal\Tests\Listeners\DrupalStandardsListener">
+        </listener>
+    </listeners>
+    <!-- Filter for coverage reports. -->
+    <filter>
+        <whitelist>
+            <directory>../web/modules/custom</directory>
+            <!-- By definition test classes have no tests. -->
+            <exclude>
+                <directory suffix="Test.php">../</directory>
+                <directory suffix="TestBase.php">../</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/web/modules/custom/dbcdk_community/tests/src/Unit/Content/FlaggableContentTest.php
+++ b/web/modules/custom/dbcdk_community/tests/src/Unit/Content/FlaggableContentTest.php
@@ -21,6 +21,15 @@ use Drupal\Tests\UnitTestCase;
 class FlaggableContentTest extends UnitTestCase {
 
   /**
+   * Test that objects can be wrapped as flaggable and returned.
+   */
+  public function testObject() {
+    $object = new \stdClass();
+    $flaggable = new FlaggableContent($object);
+    $this->assertEquals($object, $flaggable->getObject());
+  }
+
+  /**
    * Test that a single flag can be set and retrieved.
    */
   public function testAddFlag() {


### PR DESCRIPTION
Update composer test scripts for reporting code coverage.
Update Scrutinizer config to run tests and show code coverage.
