### PR TITLE
Handle profile favoriteLibrary as an array

### DIFF
--- a/web/modules/custom/dbcdk_community/src/Form/ProfileEditForm.php
+++ b/web/modules/custom/dbcdk_community/src/Form/ProfileEditForm.php
@@ -185,7 +185,7 @@ class ProfileEditForm extends FormBase implements ContainerInjectionInterface {
     $form['favoriteLibrary'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Library'),
-      '#default_value' => ((!empty($library->libraryId)) ? $library->libraryId : ''),
+      '#default_value' => ((!empty($library['libraryId'])) ? $library['libraryId'] : ''),
       '#description' => $this->t('The library id for users favorite library'),
     ];
 

--- a/web/modules/custom/dbcdk_community/src/Plugin/Block/ProfileBlock.php
+++ b/web/modules/custom/dbcdk_community/src/Plugin/Block/ProfileBlock.php
@@ -206,7 +206,7 @@ class ProfileBlock extends BlockBase implements ContainerFactoryPluginInterface 
 
         case 'library':
           $library = $profile->getFavoriteLibrary();
-          $value = (!empty($library->libraryId)) ? $library->libraryId : '';
+          $value = (!empty($library['libraryId'])) ? $library['libraryId'] : '';
           break;
 
         default:


### PR DESCRIPTION
The return value for "Favourite Library" is not an object anymore but has been changed to an array after updating the Swagger Client Generator.
