### PR TITLE
Fix flagged content list pager

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "phpunit/phpunit": "~4.8",
         "jarnaiz/behat-junit-formatter": "^1.3",
         "fzaninotto/faker": "^1.5",
-        "drupal/coder": "^8.2"
+        "drupal/coder": "^8.2",
+        "php-mock/php-mock-phpunit": "^1.1"
     },
     "conflict": {
         "drupal/drupal": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "1dff259f09dbd3e9c21941a1884ef945",
-    "content-hash": "6a7b28c2751e3a3b999e2a39dd4a008d",
+    "hash": "e1af3e1748f1b5decf4d091a8dc7910a",
+    "content-hash": "ead0cc79d555f653c6be5d2e11a2523b",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -1000,7 +1000,8 @@
             "type": "drupal-core",
             "extra": {
                 "patches_applied": {
-                    "Support tests in contrib folder": "https://www.drupal.org/files/issues/2499239_77.patch"
+                    "2499239: Support tests in contrib folder": "https://www.drupal.org/files/issues/2499239_77.patch",
+                    "2408549: Notify about overridden configuration": "https://www.drupal.org/files/issues/config-override-warning-2408549-29.patch"
                 }
             },
             "autoload": {
@@ -1060,12 +1061,16 @@
                     "dev-8.x-3.x": "8.3.x-dev"
                 },
                 "patches_applied": {
-                    "Add permission condition": "https://www.drupal.org/files/issues/2665692-ctools-6.patch"
+                    "2665692: Add permission condition": "https://www.drupal.org/files/issues/2665692-ctools-6.patch"
                 }
             },
             "notification-url": "https://packagist.drupal-composer.org/downloads/",
+            "license": [
+                "GPL-2.0+"
+            ],
             "description": "Provides a number of utility and helper APIs for Drupal developers and site builders.",
-            "homepage": "https://www.drupal.org/project/ctools"
+            "homepage": "https://www.drupal.org/project/ctools",
+            "time": "2016-02-05 19:52:56"
         },
         {
             "name": "drupal/page_manager",
@@ -1098,7 +1103,7 @@
                     "dev-8.x-1.x": "8.1.x-dev"
                 },
                 "patches_applied": {
-                    "Fix warning when running tests": "https://www.drupal.org/files/issues/page_managar-pagetesthelpertrait-2684281-2.patch"
+                    "2684281: Fix warning when running tests": "https://www.drupal.org/files/issues/page_managar-pagetesthelpertrait-2684281-2.patch"
                 }
             },
             "notification-url": "https://packagist.drupal-composer.org/downloads/",
@@ -4979,6 +4984,172 @@
             "description": "Virtual file system to mock the real file system in unit tests.",
             "homepage": "http://vfs.bovigo.org/",
             "time": "2016-01-13 09:41:49"
+        },
+        {
+            "name": "php-mock/php-mock",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-mock/php-mock.git",
+                "reference": "bfa2d17d64dbf129073a7ba2051a96ce52749570"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-mock/php-mock/zipball/bfa2d17d64dbf129073a7ba2051a96ce52749570",
+                "reference": "bfa2d17d64dbf129073a7ba2051a96ce52749570",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5",
+                "phpunit/php-text-template": "^1"
+            },
+            "replace": {
+                "malkusch/php-mock": "*"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4|^5"
+            },
+            "suggest": {
+                "php-mock/php-mock-mockery": "Allows using PHPMockery for Mockery integration",
+                "php-mock/php-mock-phpunit": "Allows integration into PHPUnit testcase with the trait PHPMock."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "phpmock\\": [
+                        "classes/",
+                        "tests/unit/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "WTFPL"
+            ],
+            "authors": [
+                {
+                    "name": "Markus Malkusch",
+                    "email": "markus@malkusch.de",
+                    "homepage": "http://markus.malkusch.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP-Mock can mock built-in PHP functions (e.g. time()). PHP-Mock relies on PHP's namespace fallback policy. No further extension is needed.",
+            "homepage": "https://github.com/php-mock/php-mock",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "function",
+                "mock",
+                "stub",
+                "test",
+                "test double"
+            ],
+            "time": "2015-11-11 22:37:09"
+        },
+        {
+            "name": "php-mock/php-mock-integration",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-mock/php-mock-integration.git",
+                "reference": "e83fb65dd20cd3cf250d554cbd4682b96b684f4b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-mock/php-mock-integration/zipball/e83fb65dd20cd3cf250d554cbd4682b96b684f4b",
+                "reference": "e83fb65dd20cd3cf250d554cbd4682b96b684f4b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5",
+                "php-mock/php-mock": "^1",
+                "phpunit/php-text-template": "^1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4|^5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "phpmock\\integration\\": "classes/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "WTFPL"
+            ],
+            "authors": [
+                {
+                    "name": "Markus Malkusch",
+                    "email": "markus@malkusch.de",
+                    "homepage": "http://markus.malkusch.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Integration package for PHP-Mock",
+            "homepage": "https://github.com/php-mock/php-mock-integration",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "function",
+                "mock",
+                "stub",
+                "test",
+                "test double"
+            ],
+            "time": "2015-10-26 21:21:42"
+        },
+        {
+            "name": "php-mock/php-mock-phpunit",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-mock/php-mock-phpunit.git",
+                "reference": "d2edb32ec05584bb6bd8f1b7e94284022fb12d75"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-mock/php-mock-phpunit/zipball/d2edb32ec05584bb6bd8f1b7e94284022fb12d75",
+                "reference": "d2edb32ec05584bb6bd8f1b7e94284022fb12d75",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5",
+                "php-mock/php-mock-integration": "^1",
+                "phpunit/phpunit": "^4.0.0 || ^5.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "phpmock\\phpunit\\": "classes/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "WTFPL"
+            ],
+            "authors": [
+                {
+                    "name": "Markus Malkusch",
+                    "email": "markus@malkusch.de",
+                    "homepage": "http://markus.malkusch.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Mock built-in PHP functions (e.g. time()) with PHPUnit. This package relies on PHP's namespace fallback policy. No further extension is needed.",
+            "homepage": "https://github.com/php-mock/php-mock-phpunit",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "function",
+                "mock",
+                "phpunit",
+                "stub",
+                "test",
+                "test double"
+            ],
+            "time": "2015-11-04 23:39:54"
         },
         {
             "name": "phpdocumentor/reflection-docblock",

--- a/web/modules/custom/dbcdk_community/src/Plugin/Block/FlaggedContentList.php
+++ b/web/modules/custom/dbcdk_community/src/Plugin/Block/FlaggedContentList.php
@@ -146,7 +146,7 @@ class FlaggedContentList extends BlockBase implements ContainerFactoryPluginInte
         $this->t('Details'),
         $this->t('Link'),
       ],
-      '#data' => [],
+      '#rows' => [],
       '#empty' => $this->t('There is currently no flagged content'),
     ];
 
@@ -178,7 +178,7 @@ class FlaggedContentList extends BlockBase implements ContainerFactoryPluginInte
       }
 
       $table['#rows'][] = [
-        [
+        'content' => [
           'data' => [
             '#theme' => 'dbcdk_community__flagged_content__content',
             '#content' => $content_element->getContent(),
@@ -186,11 +186,11 @@ class FlaggedContentList extends BlockBase implements ContainerFactoryPluginInte
             '#video_collection_count' => count($this->flaggableContentRepository->getVideoCollections($content_element)),
           ],
         ],
-        count($content_element->getFlags()),
-        $this->dateFormatter->format($content_element->getLatestFlag()->getTimeFlagged()->getTimestamp(), 'dbcdk_community_service_date_time'),
-        $content_element->getLatestFlag()->getDescription(),
-        $details_link,
-        $community_site_link,
+        'num_flags' => count($content_element->getFlags()),
+        'flag_time' => $this->dateFormatter->format($content_element->getLatestFlag()->getTimeFlagged()->getTimestamp(), 'dbcdk_community_service_date_time'),
+        'flag_text' => $content_element->getLatestFlag()->getDescription(),
+        'details' => $details_link,
+        'link' => $community_site_link,
       ];
     }
 

--- a/web/modules/custom/dbcdk_community/src/Plugin/Block/FlaggedContentList.php
+++ b/web/modules/custom/dbcdk_community/src/Plugin/Block/FlaggedContentList.php
@@ -151,7 +151,7 @@ class FlaggedContentList extends BlockBase implements ContainerFactoryPluginInte
     ];
 
     /* @var \Drupal\dbcdk_community\Content\FlaggableContent[] $page_content_elements */
-    $page_content_elements = array_slice($all_content_elements, $page, $content_per_page);
+    $page_content_elements = array_slice($all_content_elements, $page * $content_per_page, $content_per_page);
     foreach ($page_content_elements as $content_element) {
 
       try {

--- a/web/modules/custom/dbcdk_community/tests/src/Unit/Plugin/Block/BlockTestBase.php
+++ b/web/modules/custom/dbcdk_community/tests/src/Unit/Plugin/Block/BlockTestBase.php
@@ -6,12 +6,15 @@
 
 namespace Drupal\Tests\dbcdk_community\Unit\Plugin\Block;
 
+use Drupal\Core\Link;
 use Drupal\Tests\UnitTestCase;
+use phpmock\phpunit\PHPMock;
 
 /**
  * Base class for tests dealing with community service blocks.
  */
 class BlockTestBase extends UnitTestCase {
+  use PHPMock;
 
   /* @var \PHPUnit_Framework_MockObject_MockObject */
   protected $urlGenerator;
@@ -31,6 +34,12 @@ class BlockTestBase extends UnitTestCase {
 
   /* @var \PHPUnit_Framework_MockObject_MockObject */
   protected $flaggableContentRepository;
+
+  /* @var \PHPUnit_Framework_MockObject_MockObject */
+  protected $pager;
+
+  /* @var \PHPUnit_Framework_MockObject_MockObject */
+  protected $message;
 
   /**
    * {@inheritdoc}
@@ -59,6 +68,11 @@ class BlockTestBase extends UnitTestCase {
     $this->dateFormatter = $this->getMockBuilder(
       'Drupal\Core\Datetime\DateFormatter'
     )->disableOriginalConstructor()->getMock();
+
+    $namespace = '\Drupal\dbcdk_community\Plugin\Block';
+    $this->pager = $this->getFunctionMock($namespace, 'pager_default_initialize');
+
+    $this->message = $this->getFunctionMock($namespace, 'drupal_set_message');
   }
 
   /**
@@ -111,7 +125,7 @@ class BlockTestBase extends UnitTestCase {
     $this->assertInstanceOf('\Drupal\Core\Link', $table['#rows'][$row_id][1]);
     /* @var \Drupal\Core\Link $actual_link */
     $actual_link = $table['#rows'][$row_id][1];
-    $this->assertEquals($expected_url, $actual_link->getUrl()->getUri(), $message);
+    $this->assertLinkUrl($expected_url, $actual_link, $message);
   }
 
   /**
@@ -143,6 +157,20 @@ class BlockTestBase extends UnitTestCase {
    */
   protected function assertNoDetails(array $table, $message = NULL) {
     $this->assertEmpty($table['#rows'], $message);
+  }
+
+  /**
+   * Assert that a link points to a specific url.
+   *
+   * @param string $expected_url
+   *   The expected url for the link.
+   * @param Link $link
+   *   The actual link.
+   * @param string $message
+   *   The message to display if the assertion fails.
+   */
+  protected function assertLinkUrl($expected_url, Link $link, $message = NULL) {
+    $this->assertEquals($expected_url, $link->getUrl()->getUri(), $message);
   }
 
 }

--- a/web/modules/custom/dbcdk_community/tests/src/Unit/Plugin/Block/FlaggedContentListTest.php
+++ b/web/modules/custom/dbcdk_community/tests/src/Unit/Plugin/Block/FlaggedContentListTest.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ * @file
+ * Definition of FlaggedContentListTest.
+ */
+
+namespace Drupal\Tests\dbcdk_community\Unit\Plugin\Block;
+
+use DBCDK\CommunityServices\ApiException;
+use DBCDK\CommunityServices\Model\Flag;
+use DBCDK\CommunityServices\Model\Post;
+use Drupal\dbcdk_community\Content\FlaggableContent;
+use Drupal\dbcdk_community\Plugin\Block\FlaggedContentList;
+
+/**
+ * Test class for FlaggedContentList block.
+ *
+ * @group dbcdk_community
+ */
+class FlaggedContentListTest extends BlockTestBase {
+
+  /**
+   * Generate a new FlaggedContentList wired up with mocks.
+   *
+   * @return \Drupal\dbcdk_community\Plugin\Block\FlaggedContentList
+   *   New block ready for testing.
+   */
+  public function newFlaggedContentList() {
+    $list = new FlaggedContentList(
+      [],
+      NULL,
+      NULL,
+      $this->logger,
+      $this->flaggableContentRepository,
+      $this->urlGenerator,
+      $this->dateFormatter
+    );
+
+    $list->setStringTranslation($this->translation);
+
+    return $list;
+  }
+
+  /**
+   * Test list with a single flagged content element.
+   */
+  public function testSingleEntryList() {
+    $post_content = 'Post content';
+    $time_flagged = new \DateTime();
+    $flag_text = 'Flag text';
+
+    $post = new Post();
+    $post->setContent($post_content);
+    $flaggable_content = new FlaggableContent($post);
+    $flaggable_content->addFlag((new Flag())
+        ->setDescription($flag_text)
+        ->setTimeFlagged($time_flagged)
+    );
+    $this->flaggableContentRepository->method('getContentWithUnreadFlags')->willReturn([
+      $flaggable_content,
+    ]);
+
+    $date_format = 'YMD';
+    $this->dateFormatter->method('format')->willReturn($time_flagged->format($date_format));
+
+    $url = 'http://biblo.dk';
+    $this->urlGenerator->method('generate')->willReturnMap([
+      [$post, $url],
+    ]);
+
+    // With only a single element the pager should return page 0.
+    $this->pager->expects($this->once())->willReturn(0);
+
+    $list = $this->newFlaggedContentList();
+    $result = $list->build();
+
+    $this->assertCount(1, $result['table']['#rows']);
+
+    // Check that a row contains the expected data.
+    $row = array_shift($result['table']['#rows']);
+    $this->assertFlaggedContent($post_content, $row['content']);
+    $this->assertEquals(1, $row['num_flags']);
+    $this->assertEquals($time_flagged->format($date_format), $row['flag_time']);
+    $this->assertEquals($flag_text, $row['flag_text']);
+    // We only check that a details link is set. The link text does not contain
+    // references to the content as that is displayed in other columns. The url
+    // uses a route which is set internally.
+    $this->assertNotEmpty($row['details']);
+    $this->assertLinkUrl($url, $row['link']);
+  }
+
+  /**
+   * Test list with multiple pages.
+   */
+  public function testMultiplePagesList() {
+    // Generate a set of mock flaggable content which will span multiple pages
+    // in the list.
+    $flagged_content = [];
+    // This number is aligned with the hardcoded value in the block.
+    $posts_per_page = 10;
+    // By choosing 21 we should get an initial page, a full subsequent page and
+    // a partial last page.
+    $num_posts = 21;
+    $num_pages = ceil($num_posts / $posts_per_page);
+    foreach (range(0, $num_posts - 1) as $post_id) {
+      $post = new Post();
+      // We set the content for each element to be a unique count. The list does
+      // not contain the object or show the id so this is the best we can do to
+      // have something to use when checking for equality.
+      $post->setContent($post_id);
+      $flaggable_content = new FlaggableContent($post);
+      $flaggable_content->addFlag((new Flag())->setTimeFlagged(new \DateTime()));
+
+      $flagged_content[$post_id] = $flaggable_content;
+    }
+    $this->flaggableContentRepository->method('getContentWithUnreadFlags')->willReturn($flagged_content);
+
+    // Make the pager return a page count increasing by one for each call.
+    $this->pager->expects($this->any())->willReturnCallback(function() {
+      static $page;
+      $page = (!isset($page)) ? 0 : $page;
+      return $page++;
+    });
+
+    // Test list content for each page.
+    foreach (range(1, $num_pages) as $page) {
+      $list = $this->newFlaggedContentList();
+      $result = $list->build();
+
+      // Expect a full count except when we are on the last page.
+      $expected_count = ($page == $num_pages) ? $num_posts % $posts_per_page : $posts_per_page;
+      $this->assertCount($expected_count, $result['table']['#rows']);
+
+      // Based on how we set the content for the posts then the content of the
+      // first row of the paged result should be the entry number from the total
+      // set - 0-indexed. E.g. first row on page 1 should have the content 10.
+      $row = array_shift($result['table']['#rows']);
+      $this->assertFlaggedContent((($page - 1) * $posts_per_page), $row['content']);
+    }
+
+  }
+
+  /**
+   * Test list without any elements.
+   */
+  public function testNoContent() {
+    $this->flaggableContentRepository->method('getContentWithUnreadFlags')->willReturn([]);
+
+    $list = $this->newFlaggedContentList();
+    $result = $list->build();
+
+    $this->assertEmpty($result['table']['#rows']);
+  }
+
+  /**
+   * Test list with an exception thrown from the repository.
+   */
+  public function testApiException() {
+    $this->flaggableContentRepository->method('getContentWithUnreadFlags')->willThrowException(new ApiException());
+
+    // API exceptions should be logged and a message shown to the user.
+    $this->logger->expects($this->once())->method('error');
+    $this->message->expects($this->once());
+
+    $list = $this->newFlaggedContentList();
+    $result = $list->build();
+
+    $this->assertEmpty($result['table']['#rows']);
+  }
+
+  /**
+   * Assert that a render array for flagged content should have certain content.
+   *
+   * @param string $expected
+   *   The expected content.
+   * @param array $actual_render_element
+   *   The render array.
+   */
+  protected function assertFlaggedContent($expected, array $actual_render_element) {
+    $this->assertEquals($expected, $actual_render_element['data']['#content']);
+  }
+
+}


### PR DESCRIPTION
Also add more unit tests to make sure that it does not happen again.

[PHPMock](https://github.com/php-mock/php-mock-phpunit) makes it possible to mock static Drupal calls which are not migrated to services yet.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dbcdk/biblo-admin/75)

<!-- Reviewable:end -->
