### PR TITLE
Add Article content type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "drupal/page_manager": "^8.1",
         "drupal/monolog": "^8.1",
         "drupal/paragraphs": "^8.1",
-        "drupal/video": "^8.1"
+        "drupal/video_embed_field": "^8"
     },
     "require-dev": {
         "behat/behat": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,9 @@
         "drupal/console": "~0.10",
         "drupal/adminimal_theme": "^8.1",
         "drupal/page_manager": "^8.1",
-        "drupal/monolog": "^8.1"
+        "drupal/monolog": "^8.1",
+        "drupal/paragraphs": "^8.1",
+        "drupal/video": "^8.1"
     },
     "require-dev": {
         "behat/behat": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -1244,22 +1244,32 @@
             "time": "2015-11-17 13:21:21"
         },
         {
-            "name": "drupal/video",
-            "version": "8.1.2",
+            "name": "drupal/video_embed_field",
+            "version": "8.1.0-rc8",
             "source": {
                 "type": "git",
-                "url": "https://git.drupal.org/project/video",
-                "reference": "a0f381dcefe45090e8f1de41fd32e42965c78a91"
+                "url": "https://git.drupal.org/project/video_embed_field",
+                "reference": "4c01b410084ff35ff3995dba2d3c5dd878544e9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/video-8.x-1.2.zip",
-                "reference": null,
+                "url": "https://ftp.drupal.org/files/projects/video_embed_field-8.x-1.0-rc8.zip",
+                "reference": "4c01b410084ff35ff3995dba2d3c5dd878544e9e",
                 "shasum": null
             },
             "require": {
                 "drupal/core": "8.*",
-                "drupal/file": "8.*"
+                "drupal/field": "8.*"
+            },
+            "replace": {
+                "drupal/video_embed_media": "self.version",
+                "drupal/video_embed_wysiwyg": "self.version"
+            },
+            "suggest": {
+                "drupal/ckeditor": "Required by drupal/video_embed_wysiwyg",
+                "drupal/core": "Required by drupal/video_embed_media, drupal/video_embed_wysiwyg",
+                "drupal/field": "Required by drupal/video_embed_wysiwyg",
+                "drupal/media_entity": "Required by drupal/video_embed_media"
             },
             "type": "drupal-module",
             "extra": {
@@ -1275,9 +1285,9 @@
             "license": [
                 "GPL-2.0+"
             ],
-            "description": "A field type for storing uploaded or embedded videos.",
-            "homepage": "https://www.drupal.org/project/video",
-            "time": "2016-02-14 17:12:08"
+            "description": "A field type for displaying videos from 3rd party providers such as YouTube and Vimeo.",
+            "homepage": "https://www.drupal.org/project/video_embed_field",
+            "time": "2016-04-29 11:04:49"
         },
         {
             "name": "drush/drush",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "2e6eb69cefb343322a55edeb66564bd4",
-    "content-hash": "37f12feb73ff96279e65f985822d7971",
+    "hash": "49014f1f5d0426829d96da22ac1862cd",
+    "content-hash": "df0b2535e08df5a5859b94dd0c6c770d",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -1065,12 +1065,39 @@
                 }
             },
             "notification-url": "https://packagist.drupal-composer.org/downloads/",
+            "description": "Provides a number of utility and helper APIs for Drupal developers and site builders.",
+            "homepage": "https://www.drupal.org/project/ctools"
+        },
+        {
+            "name": "drupal/entity_reference_revisions",
+            "version": "8.1.0-rc6",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupal.org/project/entity_reference_revisions.git",
+                "reference": "c9056323e728586436688d6aa1310a0b60c241d1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/entity_reference_revisions-8.x-1.0-rc6.zip",
+                "reference": "c9056323e728586436688d6aa1310a0b60c241d1",
+                "shasum": null
+            },
+            "require": {
+                "drupal/core": "8.*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-8.x-1.x": "8.1.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.drupal-composer.org/downloads/",
             "license": [
                 "GPL-2.0+"
             ],
-            "description": "Provides a number of utility and helper APIs for Drupal developers and site builders.",
-            "homepage": "https://www.drupal.org/project/ctools",
-            "time": "2016-02-05 19:52:56"
+            "description": "Adds a Entity Reference field type with revision support.",
+            "homepage": "https://www.drupal.org/project/entity_reference_revisions",
+            "time": "2016-04-12 23:57:54"
         },
         {
             "name": "drupal/monolog",
@@ -1169,6 +1196,88 @@
             "description": "Provides a way to place blocks on a custom page.",
             "homepage": "https://www.drupal.org/project/page_manager",
             "time": "2016-02-16 19:47:59"
+        },
+        {
+            "name": "drupal/paragraphs",
+            "version": "8.1.0-rc4",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupal.org/project/paragraphs",
+                "reference": "740874bacb56a6a90683e7818c06ba77a638125c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/paragraphs-8.x-1.0-rc4.zip",
+                "reference": "740874bacb56a6a90683e7818c06ba77a638125c",
+                "shasum": null
+            },
+            "require": {
+                "drupal/core": "8.*",
+                "drupal/entity_reference_revisions": "8.*"
+            },
+            "replace": {
+                "drupal/paragraphs_demo": "self.version",
+                "drupal/paragraphs_type_permissions": "self.version"
+            },
+            "suggest": {
+                "drupal/block": "Required by drupal/paragraphs_demo",
+                "drupal/content_translation": "Required by drupal/paragraphs_demo",
+                "drupal/core": "Required by drupal/paragraphs_demo, drupal/paragraphs_type_permissions",
+                "drupal/field": "Required by drupal/paragraphs_demo",
+                "drupal/field_ui": "Required by drupal/paragraphs_demo",
+                "drupal/image": "Required by drupal/paragraphs_demo",
+                "drupal/language": "Required by drupal/paragraphs_demo",
+                "drupal/node": "Required by drupal/paragraphs_demo"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-8.x-1.x": "8.1.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.drupal-composer.org/downloads/",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "description": "Implements the Paragraphs entity types, Entity Reference selection type and Entity Reference field widget.",
+            "homepage": "https://www.drupal.org/project/paragraphs",
+            "time": "2015-11-17 13:21:21"
+        },
+        {
+            "name": "drupal/video",
+            "version": "8.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupal.org/project/video",
+                "reference": "a0f381dcefe45090e8f1de41fd32e42965c78a91"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/video-8.x-1.2.zip",
+                "reference": null,
+                "shasum": null
+            },
+            "require": {
+                "drupal/core": "8.*",
+                "drupal/file": "8.*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "package": "Field types",
+                    "version": "8.x-1.x"
+                },
+                "branch-alias": {
+                    "dev-8.x-1.x": "8.1.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.drupal-composer.org/downloads/",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "description": "A field type for storing uploaded or embedded videos.",
+            "homepage": "https://www.drupal.org/project/video",
+            "time": "2016-02-14 17:12:08"
         },
         {
             "name": "drush/drush",

--- a/web/config/sync/core.base_field_override.node.article.promote.yml
+++ b/web/config/sync/core.base_field_override.node.article.promote.yml
@@ -1,0 +1,22 @@
+uuid: 61a6554d-4bb5-4525-a646-7079f0653384
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.article
+id: node.article.promote
+field_name: promote
+entity_type: node
+bundle: article
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/web/config/sync/core.entity_form_display.node.article.default.yml
+++ b/web/config/sync/core.entity_form_display.node.article.default.yml
@@ -1,0 +1,68 @@
+uuid: 5104975f-3316-4924-b200-ba7e78a9fd9e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.article.field_article_type
+    - field.field.node.article.field_author
+    - field.field.node.article.field_content
+    - node.type.article
+  module:
+    - paragraphs
+id: node.article.default
+targetEntityType: node
+bundle: article
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 5
+    settings: {  }
+    third_party_settings: {  }
+  field_article_type:
+    weight: 1
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+  field_author:
+    weight: 2
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+  field_content:
+    type: entity_reference_paragraphs
+    weight: 3
+    settings:
+      title: Content
+      title_plural: Content
+      edit_mode: preview
+      add_mode: button
+      form_display_mode: default
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 6
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 7
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: 0
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: options_select
+    weight: 4
+    settings: {  }
+    third_party_settings: {  }
+hidden: {  }

--- a/web/config/sync/core.entity_form_display.node.article.default.yml
+++ b/web/config/sync/core.entity_form_display.node.article.default.yml
@@ -41,18 +41,6 @@ content:
       add_mode: button
       form_display_mode: default
     third_party_settings: {  }
-  promote:
-    type: boolean_checkbox
-    settings:
-      display_label: true
-    weight: 6
-    third_party_settings: {  }
-  sticky:
-    type: boolean_checkbox
-    settings:
-      display_label: true
-    weight: 7
-    third_party_settings: {  }
   title:
     type: string_textfield
     weight: 0
@@ -65,4 +53,6 @@ content:
     weight: 4
     settings: {  }
     third_party_settings: {  }
-hidden: {  }
+hidden:
+  promote: true
+  sticky: true

--- a/web/config/sync/core.entity_form_display.paragraph.embedded_video.default.yml
+++ b/web/config/sync/core.entity_form_display.paragraph.embedded_video.default.yml
@@ -1,0 +1,31 @@
+uuid: a1be515e-43de-4a82-bf42-662bb5c4ef5d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.embedded_video.field_embedded_video
+    - paragraphs.paragraphs_type.embedded_video
+  module:
+    - video
+id: paragraph.embedded_video.default
+targetEntityType: paragraph
+bundle: embedded_video
+mode: default
+content:
+  field_embedded_video:
+    weight: 0
+    settings:
+      allowed_providers:
+        vimeo: vimeo
+        youtube: youtube
+        dailymotion: 0
+        facebook: 0
+        instagram: 0
+        vine: 0
+      file_directory: 'video-thumbnails/[date:custom:Y]-[date:custom:m]'
+      uri_scheme: public
+    third_party_settings: {  }
+    type: video_embed
+hidden:
+  created: true
+  uid: true

--- a/web/config/sync/core.entity_form_display.paragraph.embedded_video.default.yml
+++ b/web/config/sync/core.entity_form_display.paragraph.embedded_video.default.yml
@@ -6,7 +6,7 @@ dependencies:
     - field.field.paragraph.embedded_video.field_embedded_video
     - paragraphs.paragraphs_type.embedded_video
   module:
-    - video
+    - video_embed_field
 id: paragraph.embedded_video.default
 targetEntityType: paragraph
 bundle: embedded_video
@@ -14,18 +14,9 @@ mode: default
 content:
   field_embedded_video:
     weight: 0
-    settings:
-      allowed_providers:
-        vimeo: vimeo
-        youtube: youtube
-        dailymotion: 0
-        facebook: 0
-        instagram: 0
-        vine: 0
-      file_directory: 'video-thumbnails/[date:custom:Y]-[date:custom:m]'
-      uri_scheme: public
+    settings: {  }
     third_party_settings: {  }
-    type: video_embed
+    type: video_embed_field_textfield
 hidden:
   created: true
   uid: true

--- a/web/config/sync/core.entity_form_display.paragraph.image.default.yml
+++ b/web/config/sync/core.entity_form_display.paragraph.image.default.yml
@@ -1,0 +1,25 @@
+uuid: 319a1522-1182-40ce-b72b-439d1bd10324
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.image.field_image
+    - image.style.thumbnail
+    - paragraphs.paragraphs_type.image
+  module:
+    - image
+id: paragraph.image.default
+targetEntityType: paragraph
+bundle: image
+mode: default
+content:
+  field_image:
+    weight: 0
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+    type: image_image
+hidden:
+  created: true
+  uid: true

--- a/web/config/sync/core.entity_form_display.paragraph.text.default.yml
+++ b/web/config/sync/core.entity_form_display.paragraph.text.default.yml
@@ -1,0 +1,24 @@
+uuid: c5e414ab-7658-4fbb-9223-3559e7ffb236
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.text.field_textarea
+    - paragraphs.paragraphs_type.text
+  module:
+    - text
+id: paragraph.text.default
+targetEntityType: paragraph
+bundle: text
+mode: default
+content:
+  field_textarea:
+    weight: 0
+    settings:
+      rows: 8
+      placeholder: ''
+    third_party_settings: {  }
+    type: text_textarea
+hidden:
+  created: true
+  uid: true

--- a/web/config/sync/core.entity_form_display.taxonomy_term.article_types.default.yml
+++ b/web/config/sync/core.entity_form_display.taxonomy_term.article_types.default.yml
@@ -1,0 +1,20 @@
+uuid: 3b4a8bbf-3cb3-4fd5-bc34-525cf06207be
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.article_types
+id: taxonomy_term.article_types.default
+targetEntityType: taxonomy_term
+bundle: article_types
+mode: default
+content:
+  name:
+    type: string_textfield
+    weight: 0
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  description: true

--- a/web/config/sync/core.entity_view_display.node.article.default.yml
+++ b/web/config/sync/core.entity_view_display.node.article.default.yml
@@ -1,0 +1,41 @@
+uuid: 4a50955b-767b-4f31-a404-4b309b161a37
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.article.field_article_type
+    - field.field.node.article.field_author
+    - field.field.node.article.field_content
+    - node.type.article
+  module:
+    - entity_reference_revisions
+    - user
+id: node.article.default
+targetEntityType: node
+bundle: article
+mode: default
+content:
+  field_article_type:
+    weight: 1
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+  field_author:
+    weight: 0
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+  field_content:
+    type: entity_reference_revisions_entity_view
+    weight: 2
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+hidden:
+  links: true

--- a/web/config/sync/core.entity_view_display.node.article.teaser.yml
+++ b/web/config/sync/core.entity_view_display.node.article.teaser.yml
@@ -1,0 +1,23 @@
+uuid: cd3d2aa7-a0cb-4d38-b700-bd28065adbe1
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.article.field_article_type
+    - field.field.node.article.field_author
+    - field.field.node.article.field_content
+    - node.type.article
+  module:
+    - user
+id: node.article.teaser
+targetEntityType: node
+bundle: article
+mode: teaser
+content:
+  links:
+    weight: 100
+hidden:
+  field_article_type: true
+  field_author: true
+  field_content: true

--- a/web/config/sync/core.entity_view_display.paragraph.embedded_video.default.yml
+++ b/web/config/sync/core.entity_view_display.paragraph.embedded_video.default.yml
@@ -14,12 +14,12 @@ mode: default
 content:
   field_embedded_video:
     weight: 0
-    label: above
+    label: hidden
     settings:
-      responsive: true
-      width: '854'
-      height: '480'
-      autoplay: true
+      width: '640'
+      height: '360'
+      autoplay: false
+      responsive: false
     third_party_settings: {  }
     type: video_embed_field_video
 hidden:

--- a/web/config/sync/core.entity_view_display.paragraph.embedded_video.default.yml
+++ b/web/config/sync/core.entity_view_display.paragraph.embedded_video.default.yml
@@ -6,7 +6,7 @@ dependencies:
     - field.field.paragraph.embedded_video.field_embedded_video
     - paragraphs.paragraphs_type.embedded_video
   module:
-    - video
+    - video_embed_field
 id: paragraph.embedded_video.default
 targetEntityType: paragraph
 bundle: embedded_video
@@ -14,13 +14,14 @@ mode: default
 content:
   field_embedded_video:
     weight: 0
-    label: hidden
+    label: above
     settings:
+      responsive: true
+      width: '854'
+      height: '480'
       autoplay: true
-      width: '640'
-      height: '360'
     third_party_settings: {  }
-    type: video_embed_player
+    type: video_embed_field_video
 hidden:
   created: true
   uid: true

--- a/web/config/sync/core.entity_view_display.paragraph.embedded_video.default.yml
+++ b/web/config/sync/core.entity_view_display.paragraph.embedded_video.default.yml
@@ -1,0 +1,26 @@
+uuid: d92f6e6b-229f-4cee-8d00-f0c97d03d871
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.embedded_video.field_embedded_video
+    - paragraphs.paragraphs_type.embedded_video
+  module:
+    - video
+id: paragraph.embedded_video.default
+targetEntityType: paragraph
+bundle: embedded_video
+mode: default
+content:
+  field_embedded_video:
+    weight: 0
+    label: hidden
+    settings:
+      autoplay: true
+      width: '640'
+      height: '360'
+    third_party_settings: {  }
+    type: video_embed_player
+hidden:
+  created: true
+  uid: true

--- a/web/config/sync/core.entity_view_display.paragraph.embedded_video.preview.yml
+++ b/web/config/sync/core.entity_view_display.paragraph.embedded_video.preview.yml
@@ -5,22 +5,23 @@ dependencies:
   config:
     - core.entity_view_mode.paragraph.preview
     - field.field.paragraph.embedded_video.field_embedded_video
+    - image.style.large
     - paragraphs.paragraphs_type.embedded_video
   module:
-    - video
+    - video_embed_field
 id: paragraph.embedded_video.preview
 targetEntityType: paragraph
 bundle: embedded_video
 mode: preview
 content:
   field_embedded_video:
+    type: video_embed_field_thumbnail
     weight: 0
     label: hidden
     settings:
       image_style: large
       link_image_to: ''
     third_party_settings: {  }
-    type: video_embed_thumbnail
 hidden:
   created: true
   uid: true

--- a/web/config/sync/core.entity_view_display.paragraph.embedded_video.preview.yml
+++ b/web/config/sync/core.entity_view_display.paragraph.embedded_video.preview.yml
@@ -1,0 +1,26 @@
+uuid: ee24f8ec-df0e-4814-a909-9ae475c1634a
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.preview
+    - field.field.paragraph.embedded_video.field_embedded_video
+    - paragraphs.paragraphs_type.embedded_video
+  module:
+    - video
+id: paragraph.embedded_video.preview
+targetEntityType: paragraph
+bundle: embedded_video
+mode: preview
+content:
+  field_embedded_video:
+    weight: 0
+    label: hidden
+    settings:
+      image_style: large
+      link_image_to: ''
+    third_party_settings: {  }
+    type: video_embed_thumbnail
+hidden:
+  created: true
+  uid: true

--- a/web/config/sync/core.entity_view_display.paragraph.image.default.yml
+++ b/web/config/sync/core.entity_view_display.paragraph.image.default.yml
@@ -1,0 +1,25 @@
+uuid: 4d83e931-b99d-43f6-891e-302d5b512183
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.image.field_image
+    - paragraphs.paragraphs_type.image
+  module:
+    - image
+id: paragraph.image.default
+targetEntityType: paragraph
+bundle: image
+mode: default
+content:
+  field_image:
+    weight: 0
+    label: hidden
+    settings:
+      image_style: ''
+      image_link: ''
+    third_party_settings: {  }
+    type: image
+hidden:
+  created: true
+  uid: true

--- a/web/config/sync/core.entity_view_display.paragraph.image.preview.yml
+++ b/web/config/sync/core.entity_view_display.paragraph.image.preview.yml
@@ -1,0 +1,27 @@
+uuid: dd6599e8-0fa2-4c1a-ac03-3dac3ee142a5
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.preview
+    - field.field.paragraph.image.field_image
+    - image.style.large
+    - paragraphs.paragraphs_type.image
+  module:
+    - image
+id: paragraph.image.preview
+targetEntityType: paragraph
+bundle: image
+mode: preview
+content:
+  field_image:
+    weight: 0
+    label: hidden
+    settings:
+      image_style: large
+      image_link: ''
+    third_party_settings: {  }
+    type: image
+hidden:
+  created: true
+  uid: true

--- a/web/config/sync/core.entity_view_display.paragraph.text.default.yml
+++ b/web/config/sync/core.entity_view_display.paragraph.text.default.yml
@@ -1,0 +1,23 @@
+uuid: f17b61ce-baaa-46e9-8e06-6cd5c1a3e018
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.text.field_textarea
+    - paragraphs.paragraphs_type.text
+  module:
+    - text
+id: paragraph.text.default
+targetEntityType: paragraph
+bundle: text
+mode: default
+content:
+  field_textarea:
+    weight: 0
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+hidden:
+  created: true
+  uid: true

--- a/web/config/sync/core.entity_view_display.paragraph.text.preview.yml
+++ b/web/config/sync/core.entity_view_display.paragraph.text.preview.yml
@@ -1,0 +1,25 @@
+uuid: 9ec13439-8d9d-4472-9736-548ab67fb420
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.preview
+    - field.field.paragraph.text.field_textarea
+    - paragraphs.paragraphs_type.text
+  module:
+    - text
+id: paragraph.text.preview
+targetEntityType: paragraph
+bundle: text
+mode: preview
+content:
+  field_textarea:
+    weight: 0
+    label: hidden
+    settings:
+      trim_length: 280
+    third_party_settings: {  }
+    type: text_trimmed
+hidden:
+  created: true
+  uid: true

--- a/web/config/sync/core.entity_view_mode.paragraph.preview.yml
+++ b/web/config/sync/core.entity_view_mode.paragraph.preview.yml
@@ -1,0 +1,12 @@
+uuid: e7e520de-8f7b-44ea-9707-07e2700ccd23
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+_core:
+  default_config_hash: 2LM5HYaL3qdCzMYZVLKx6NxTHPZJXyk4S5kfC8aPYOg
+id: paragraph.preview
+label: Preview
+targetEntityType: paragraph
+cache: true

--- a/web/config/sync/core.entity_view_mode.taxonomy_term.full.yml
+++ b/web/config/sync/core.entity_view_mode.taxonomy_term.full.yml
@@ -1,0 +1,12 @@
+uuid: 2d9f3f27-d68a-420c-9946-70fcb9efa2b8
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+_core:
+  default_config_hash: '-PPKjsNQPvoIDjOuUAvlLocYD976MNjb9Zpgyz5_BWE'
+id: taxonomy_term.full
+label: 'Taxonomy term page'
+targetEntityType: taxonomy_term
+cache: true

--- a/web/config/sync/core.extension.yml
+++ b/web/config/sync/core.extension.yml
@@ -30,7 +30,7 @@ module:
   text: 0
   toolbar: 0
   user: 0
-  video: 0
+  video_embed_field: 0
   minimal: 1000
 theme:
   stable: 0

--- a/web/config/sync/core.extension.yml
+++ b/web/config/sync/core.extension.yml
@@ -11,21 +11,26 @@ module:
   dblog: 0
   dynamic_page_cache: 0
   editor: 0
+  entity_reference_revisions: 0
   field: 0
   file: 0
   filter: 0
   help: 0
+  image: 0
   link: 0
   node: 0
   page_cache: 0
   page_manager: 0
+  paragraphs: 0
   rest: 0
   serialization: 0
   shortcut: 0
   system: 0
+  taxonomy: 0
   text: 0
   toolbar: 0
   user: 0
+  video: 0
   minimal: 1000
 theme:
   stable: 0

--- a/web/config/sync/field.field.node.article.field_article_type.yml
+++ b/web/config/sync/field.field.node.article.field_article_type.yml
@@ -1,0 +1,27 @@
+uuid: a1b25aaa-1722-479a-9f1f-316a9001a830
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_article_type
+    - node.type.article
+    - taxonomy.vocabulary.article_types
+id: node.article.field_article_type
+field_name: field_article_type
+entity_type: node
+bundle: article
+label: 'Article type'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      article_types: article_types
+    sort:
+      field: _none
+    auto_create: false
+field_type: entity_reference

--- a/web/config/sync/field.field.node.article.field_author.yml
+++ b/web/config/sync/field.field.node.article.field_author.yml
@@ -1,0 +1,19 @@
+uuid: d9123a34-78df-414f-ae01-1ba87b43c3af
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_author
+    - node.type.article
+id: node.article.field_author
+field_name: field_author
+entity_type: node
+bundle: article
+label: Author
+description: 'The name of the author.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/web/config/sync/field.field.node.article.field_content.yml
+++ b/web/config/sync/field.field.node.article.field_content.yml
@@ -1,0 +1,37 @@
+uuid: ae86d8a5-c184-4981-8357-87256aff1efd
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_content
+    - node.type.article
+  module:
+    - entity_reference_revisions
+id: node.article.field_content
+field_name: field_content
+entity_type: node
+bundle: article
+label: Content
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    target_bundles:
+      text: text
+      image: image
+      embedded_video: embedded_video
+    target_bundles_drag_drop:
+      text:
+        weight: -7
+        enabled: false
+      image:
+        weight: -6
+        enabled: false
+      embedded_video:
+        weight: 4
+        enabled: false
+field_type: entity_reference_revisions

--- a/web/config/sync/field.field.paragraph.embedded_video.field_embedded_video.yml
+++ b/web/config/sync/field.field.paragraph.embedded_video.field_embedded_video.yml
@@ -1,4 +1,4 @@
-uuid: 4221d8b2-3f1f-4b4f-a301-1f9ab5698a77
+uuid: 6e9d2ad0-4c10-43b8-9001-1db534294ff4
 langcode: en
 status: true
 dependencies:
@@ -6,21 +6,20 @@ dependencies:
     - field.storage.paragraph.field_embedded_video
     - paragraphs.paragraphs_type.embedded_video
   module:
-    - video
+    - video_embed_field
 id: paragraph.embedded_video.field_embedded_video
 field_name: field_embedded_video
 entity_type: paragraph
 bundle: embedded_video
 label: 'Embedded Video'
-description: 'The URL for the <em>Youtube</em> or <em>Vimeo</em> video you wish to embed.'
+description: 'The URL for the <em>Vimeo</em> or <em>Youtube</em> video you wish to embed.'
 required: true
 translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  file_extensions: ''
-  file_directory: 'videos/[date:custom:Y]-[date:custom:m]'
-  max_filesize: ''
-  handler: 'default:file'
-  handler_settings: {  }
-field_type: video
+  allowed_providers:
+    vimeo: '0'
+    youtube: '0'
+    youtube_playlist: '0'
+field_type: video_embed_field

--- a/web/config/sync/field.field.paragraph.embedded_video.field_embedded_video.yml
+++ b/web/config/sync/field.field.paragraph.embedded_video.field_embedded_video.yml
@@ -1,0 +1,26 @@
+uuid: 4221d8b2-3f1f-4b4f-a301-1f9ab5698a77
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_embedded_video
+    - paragraphs.paragraphs_type.embedded_video
+  module:
+    - video
+id: paragraph.embedded_video.field_embedded_video
+field_name: field_embedded_video
+entity_type: paragraph
+bundle: embedded_video
+label: 'Embedded Video'
+description: 'The URL for the <em>Youtube</em> or <em>Vimeo</em> video you wish to embed.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_extensions: ''
+  file_directory: 'videos/[date:custom:Y]-[date:custom:m]'
+  max_filesize: ''
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: video

--- a/web/config/sync/field.field.paragraph.image.field_image.yml
+++ b/web/config/sync/field.field.paragraph.image.field_image.yml
@@ -1,0 +1,38 @@
+uuid: af6c357b-fa15-4418-ab26-38c2b838c771
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_image
+    - paragraphs.paragraphs_type.image
+  module:
+    - image
+id: paragraph.image.field_image
+field_name: field_image
+entity_type: paragraph
+bundle: image
+label: Image
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: true
+  title_field: true
+  title_field_required: true
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/web/config/sync/field.field.paragraph.text.field_textarea.yml
+++ b/web/config/sync/field.field.paragraph.text.field_textarea.yml
@@ -13,7 +13,7 @@ entity_type: paragraph
 bundle: text
 label: Text
 description: ''
-required: false
+required: true
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/web/config/sync/field.field.paragraph.text.field_textarea.yml
+++ b/web/config/sync/field.field.paragraph.text.field_textarea.yml
@@ -1,0 +1,21 @@
+uuid: ec438796-e45b-49d4-8300-0d799f22cc73
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_textarea
+    - paragraphs.paragraphs_type.text
+  module:
+    - text
+id: paragraph.text.field_textarea
+field_name: field_textarea
+entity_type: paragraph
+bundle: text
+label: Text
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/web/config/sync/field.storage.node.field_article_type.yml
+++ b/web/config/sync/field.storage.node.field_article_type.yml
@@ -1,0 +1,20 @@
+uuid: bcdead81-02f0-4103-9f1e-30b7e046d60d
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_article_type
+field_name: field_article_type
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/config/sync/field.storage.node.field_author.yml
+++ b/web/config/sync/field.storage.node.field_author.yml
@@ -1,0 +1,21 @@
+uuid: 3ab5a872-7477-4914-9501-1d55aa47b1ff
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_author
+field_name: field_author
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/config/sync/field.storage.node.field_content.yml
+++ b/web/config/sync/field.storage.node.field_content.yml
@@ -1,0 +1,21 @@
+uuid: 1b908dda-064c-47aa-ba11-177668621670
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - node
+    - paragraphs
+id: node.field_content
+field_name: field_content
+entity_type: node
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/config/sync/field.storage.paragraph.field_embedded_video.yml
+++ b/web/config/sync/field.storage.paragraph.field_embedded_video.yml
@@ -1,24 +1,16 @@
-uuid: 47a347ab-bb16-421a-a122-34a9de7e064c
+uuid: fb15d4b0-a356-4ba8-9400-a6b7dde65e0c
 langcode: en
 status: true
 dependencies:
   module:
-    - file
     - paragraphs
-    - video
+    - video_embed_field
 id: paragraph.field_embedded_video
 field_name: field_embedded_video
 entity_type: paragraph
-type: video
-settings:
-  default_video:
-    uuid: null
-    data: null
-  target_type: file
-  display_field: false
-  display_default: false
-  uri_scheme: public
-module: video
+type: video_embed_field
+settings: {  }
+module: video_embed_field
 locked: false
 cardinality: 1
 translatable: true

--- a/web/config/sync/field.storage.paragraph.field_embedded_video.yml
+++ b/web/config/sync/field.storage.paragraph.field_embedded_video.yml
@@ -1,0 +1,27 @@
+uuid: 47a347ab-bb16-421a-a122-34a9de7e064c
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - paragraphs
+    - video
+id: paragraph.field_embedded_video
+field_name: field_embedded_video
+entity_type: paragraph
+type: video
+settings:
+  default_video:
+    uuid: null
+    data: null
+  target_type: file
+  display_field: false
+  display_default: false
+  uri_scheme: public
+module: video
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/config/sync/field.storage.paragraph.field_image.yml
+++ b/web/config/sync/field.storage.paragraph.field_image.yml
@@ -1,0 +1,30 @@
+uuid: 8782a4e6-b23a-4fab-a600-0bacb8a29d6a
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - paragraphs
+id: paragraph.field_image
+field_name: field_image
+entity_type: paragraph
+type: image
+settings:
+  uri_scheme: public
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  target_type: file
+  display_field: false
+  display_default: false
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/config/sync/field.storage.paragraph.field_textarea.yml
+++ b/web/config/sync/field.storage.paragraph.field_textarea.yml
@@ -1,0 +1,19 @@
+uuid: 3def2d22-72bb-476e-b700-d3fccf7d913d
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - text
+id: paragraph.field_textarea
+field_name: field_textarea
+entity_type: paragraph
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/config/sync/field_ui.settings.yml
+++ b/web/config/sync/field_ui.settings.yml
@@ -1,3 +1,0 @@
-field_prefix: field_
-_core:
-  default_config_hash: Q1nMi90W6YQxKzZAgJQw7Ag9U4JrsEUwkomF0lhvbIM

--- a/web/config/sync/field_ui.settings.yml
+++ b/web/config/sync/field_ui.settings.yml
@@ -1,0 +1,3 @@
+field_prefix: field_
+_core:
+  default_config_hash: Q1nMi90W6YQxKzZAgJQw7Ag9U4JrsEUwkomF0lhvbIM

--- a/web/config/sync/filter.format.dbcdk_community_basic_markup.yml
+++ b/web/config/sync/filter.format.dbcdk_community_basic_markup.yml
@@ -4,7 +4,7 @@ status: true
 dependencies: {  }
 name: 'DBCDK Community - Basic markup'
 format: dbcdk_community_basic_markup
-weight: 0
+weight: -10
 filters:
   filter_autop:
     id: filter_autop

--- a/web/config/sync/filter.format.plain_text.yml
+++ b/web/config/sync/filter.format.plain_text.yml
@@ -6,7 +6,7 @@ _core:
   default_config_hash: NIKBt6kw_uPhNI0qtR2DnRf7mSOgAQdx7Q94SKMjXbQ
 name: 'Plain text'
 format: plain_text
-weight: -10
+weight: -9
 filters:
   filter_html_escape:
     id: filter_html_escape

--- a/web/config/sync/image.settings.yml
+++ b/web/config/sync/image.settings.yml
@@ -1,0 +1,5 @@
+preview_image: core/modules/image/sample.png
+allow_insecure_derivatives: false
+suppress_itok_output: false
+_core:
+  default_config_hash: k-yDFHbqNfpe-Srg4sdCSqaosCl2D8uwyEY5esF8gEw

--- a/web/config/sync/image.style.large.yml
+++ b/web/config/sync/image.style.large.yml
@@ -1,0 +1,17 @@
+uuid: 3f914d94-0395-4ac4-a009-9ea2ee8484ea
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: J2n0RpFzS0-bgSyxjs6rSdgxB1rb-bTAgqywNx_964M
+name: large
+label: 'Large (480×480)'
+effects:
+  ddd73aa7-4bd6-4c85-b600-bdf2b1628d1d:
+    uuid: ddd73aa7-4bd6-4c85-b600-bdf2b1628d1d
+    id: image_scale
+    weight: 0
+    data:
+      width: 480
+      height: 480
+      upscale: false

--- a/web/config/sync/image.style.medium.yml
+++ b/web/config/sync/image.style.medium.yml
@@ -1,0 +1,17 @@
+uuid: ef07e09f-1b95-44db-9446-7003120c01f2
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: Y9NmnZHQq20ASSyTNA6JnwtWrJJiSajOehGDtmUFdM0
+name: medium
+label: 'Medium (220×220)'
+effects:
+  bddf0d06-42f9-4c75-a700-a33cafa25ea0:
+    uuid: bddf0d06-42f9-4c75-a700-a33cafa25ea0
+    id: image_scale
+    weight: 0
+    data:
+      width: 220
+      height: 220
+      upscale: false

--- a/web/config/sync/image.style.thumbnail.yml
+++ b/web/config/sync/image.style.thumbnail.yml
@@ -1,0 +1,17 @@
+uuid: 0b9d5220-352c-4025-b100-f2c746042196
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: cCiWdBHgLwj5omG35lsKc4LkW4MBdmcctkVop4ol5x0
+name: thumbnail
+label: 'Thumbnail (100×100)'
+effects:
+  1cfec298-8620-4749-b100-ccb6c4500779:
+    uuid: 1cfec298-8620-4749-b100-ccb6c4500779
+    id: image_scale
+    weight: 0
+    data:
+      width: 100
+      height: 100
+      upscale: false

--- a/web/config/sync/node.type.article.yml
+++ b/web/config/sync/node.type.article.yml
@@ -1,0 +1,11 @@
+uuid: c506bda6-e0ae-4f0f-9900-a4232c4ebe8e
+langcode: en
+status: true
+dependencies: {  }
+name: Article
+type: article
+description: ''
+help: ''
+new_revision: false
+preview_mode: 0
+display_submitted: false

--- a/web/config/sync/paragraphs.paragraphs_type.embedded_video.yml
+++ b/web/config/sync/paragraphs.paragraphs_type.embedded_video.yml
@@ -1,0 +1,6 @@
+uuid: 638a66fa-b559-4db9-a900-e2e55fb8e427
+langcode: en
+status: true
+dependencies: {  }
+id: embedded_video
+label: 'Embedded Video'

--- a/web/config/sync/paragraphs.paragraphs_type.image.yml
+++ b/web/config/sync/paragraphs.paragraphs_type.image.yml
@@ -1,0 +1,6 @@
+uuid: 3981b070-7ddd-4f26-a209-9a68f886aa49
+langcode: en
+status: true
+dependencies: {  }
+id: image
+label: Image

--- a/web/config/sync/paragraphs.paragraphs_type.text.yml
+++ b/web/config/sync/paragraphs.paragraphs_type.text.yml
@@ -1,0 +1,6 @@
+uuid: b39431a7-c468-47c4-8f14-2060de752851
+langcode: en
+status: true
+dependencies: {  }
+id: text
+label: Text

--- a/web/config/sync/taxonomy.settings.yml
+++ b/web/config/sync/taxonomy.settings.yml
@@ -1,0 +1,5 @@
+maintain_index_table: true
+override_selector: false
+terms_per_page_admin: 100
+_core:
+  default_config_hash: zKpaWT6cJc1tVQQaTqatGELaCqU_oyRym6zTl27Yias

--- a/web/config/sync/taxonomy.vocabulary.article_types.yml
+++ b/web/config/sync/taxonomy.vocabulary.article_types.yml
@@ -1,0 +1,9 @@
+uuid: 36f62011-d049-46bc-9709-9ec046eb5713
+langcode: en
+status: true
+dependencies: {  }
+name: 'Article types'
+vid: article_types
+description: ''
+hierarchy: 0
+weight: 0


### PR DESCRIPTION
This PR is basically a huge stack of configuration-files doing the following:
- Update `composer.json` to include _Paragraphs_ and _Video_ modules.
- Enable the following modules:
  - Paragraphs (and entity_reference_revisions).
  - Field UI.
  - Taxonomy.
  - Image.
  - Video.
- Create a new content type called _Article_ with fields:
  - Title.
  - Article type (taxonomy ref).
  - Author (textfield).
  - Content (paragraphs ref).
- Create a taxonomy called _Article types_.
- Add Paragraphs types:
  - Text: contains a textarea field.
  - Image: contains an image field.
  - Embedded Video: contains a video field for embed url.
