### PR TITLE
Improve exception messages

### DIFF
--- a/web/modules/custom/dbcdk_community/dbcdk_community.services.yml
+++ b/web/modules/custom/dbcdk_community/dbcdk_community.services.yml
@@ -7,7 +7,7 @@ services:
   dbcdk_community.api.configuration:
     class: Drupal\dbcdk_community\CommunityApiConfiguration
   dbcdk_community.api.client:
-    class: DBCDK\CommunityServices\ApiClient
+    class: Drupal\dbcdk_community\Api\ApiClient
     arguments: ['@dbcdk_community.api.configuration']
   dbcdk_community.api.comment:
     class: DBCDK\CommunityServices\Api\CommentApi

--- a/web/modules/custom/dbcdk_community/src/Api/ApiClient.php
+++ b/web/modules/custom/dbcdk_community/src/Api/ApiClient.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @file
+ * ApiClient class definition.
+ */
+
+namespace Drupal\dbcdk_community\Api;
+
+use DBCDK\CommunityServices\ApiException;
+
+/**
+ * API client subclass tailored to the Community Service API.
+ *
+ * This adds modifications to the generated API client.
+ */
+class ApiClient extends \DBCDK\CommunityServices\ApiClient {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function callApi($resource_path, $method, $query_params, $post_data, $header_params, $response_type = NULL) {
+    try {
+      return parent::callApi($resource_path, $method, $query_params, $post_data, $header_params, $response_type);
+    }
+    catch (ApiException $e) {
+      // Improve API exception message. Normally this would a generic message
+      // "Error connecting to the API". The community service stores the
+      // specifics about the error in the response body so try to extract that
+      // and rethrow if possible.
+      $message = $e->getMessage();
+      $response_body = $e->getResponseBody();
+      if (isset($response_body->error->message)) {
+        $message = $response_body->error->message . ' ' . $message;
+      }
+      throw new ApiException($message, $e->getCode(), $e->getResponseHeaders(), $e->getResponseBody());
+    }
+  }
+
+}

--- a/web/modules/custom/dbcdk_community/src/Api/CommunityApiConfiguration.php
+++ b/web/modules/custom/dbcdk_community/src/Api/CommunityApiConfiguration.php
@@ -5,7 +5,7 @@
  * Contains \Drupal\dbcdk_community\CommunityApiConfiguration.
  */
 
-namespace Drupal\dbcdk_community;
+namespace Drupal\dbcdk_community\Api;
 
 use DBCDK\CommunityServices\Configuration as Configuration;
 


### PR DESCRIPTION
Normally the exception message in in the format:
`[http-error-code] Error connecting to the API (api-url)`

That is not very informative.

The community service keeps more information e.g. validation errors in an unstructured object in the
response body. We try to extract these if possible and rethrow.

Move the API configuration under the same Api namespace.
