### PR TITLE
Update DBCDK devel dependencies

### DIFF
--- a/web/modules/custom/dbcdk_community_devel/dbcdk_community_devel.info.yml
+++ b/web/modules/custom/dbcdk_community_devel/dbcdk_community_devel.info.yml
@@ -6,5 +6,6 @@ version: 8.x-1.0
 core: 8.x
 dependencies:
   - dbcdk_community
+  - field_ui
   - page_manager_ui
   - monolog


### PR DESCRIPTION
Include `field_ui` as a dependency for the DBCDK Community Devel module.
This is required because we've started to work with content types and taxonomies.
