### PR TITLE
Expose articles via REST

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,8 @@
             },
             "drupal/core": {
                 "2499239: Support tests in contrib folder": "https://www.drupal.org/files/issues/2499239_77.patch",
-                "2408549: Notify about overridden configuration": "https://www.drupal.org/files/issues/config-override-warning-2408549-29.patch"
+                "2408549: Notify about overridden configuration": "https://www.drupal.org/files/issues/config-override-warning-2408549-29.patch",
+                "2402533: Support canonical link templates for files": "https://www.drupal.org/files/issues/2402533_30.patch"
             },
             "drupal/page_manager": {
                 "2684281: Fix warning when running tests": "https://www.drupal.org/files/issues/page_managar-pagetesthelpertrait-2684281-2.patch"

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "drupal/paragraphs": "^8.1",
         "drupal/video_embed_field": "^8",
         "drupal/pathauto": "^8.1",
-        "drupal/token": "^8.1"
+        "drupal/token": "^8.1",
+        "drupal/restui": "^8.1"
     },
     "require-dev": {
         "behat/behat": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "fc252bfc784f0b49e1b9f2648519fa48",
-    "content-hash": "75ec60f95d4d80500872cf9feab25638",
+    "hash": "07dc0439a1766c5440c1567c30e4eae1",
+    "content-hash": "232aa924b897d844442ac813fab0e79a",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -1285,6 +1285,38 @@
             "description": "Provides a mechanism for modules to automatically generate aliases for the content they manage.",
             "homepage": "https://www.drupal.org/project/pathauto",
             "time": "2016-04-18 18:44:27"
+        },
+        {
+            "name": "drupal/restui",
+            "version": "8.1.11",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupal.org/project/restui",
+                "reference": "b32b5f8bf16b91fd1c65acbb61e82db7b706e127"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/restui-8.x-1.11.zip",
+                "reference": null,
+                "shasum": null
+            },
+            "require": {
+                "drupal/core": "8.*",
+                "drupal/rest": "8.*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-8.x-1.x": "8.1.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.drupal-composer.org/downloads/",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "description": "Provides a user interface to manage REST resources",
+            "homepage": "https://www.drupal.org/project/restui",
+            "time": "2015-12-01 13:26:14"
         },
         {
             "name": "drupal/token",

--- a/web/config/sync/image.style.large.yml
+++ b/web/config/sync/image.style.large.yml
@@ -5,13 +5,13 @@ dependencies: {  }
 _core:
   default_config_hash: J2n0RpFzS0-bgSyxjs6rSdgxB1rb-bTAgqywNx_964M
 name: large
-label: 'Large (480×480)'
+label: 'Large (1024×1024)'
 effects:
   ddd73aa7-4bd6-4c85-b600-bdf2b1628d1d:
     uuid: ddd73aa7-4bd6-4c85-b600-bdf2b1628d1d
     id: image_scale
     weight: 0
     data:
-      width: 480
-      height: 480
+      width: 1024
+      height: 1024
       upscale: false

--- a/web/config/sync/image.style.medium.yml
+++ b/web/config/sync/image.style.medium.yml
@@ -5,13 +5,13 @@ dependencies: {  }
 _core:
   default_config_hash: Y9NmnZHQq20ASSyTNA6JnwtWrJJiSajOehGDtmUFdM0
 name: medium
-label: 'Medium (220×220)'
+label: 'Medium (680×680)'
 effects:
   bddf0d06-42f9-4c75-a700-a33cafa25ea0:
     uuid: bddf0d06-42f9-4c75-a700-a33cafa25ea0
     id: image_scale
     weight: 0
     data:
-      width: 220
-      height: 220
+      width: 680
+      height: 680
       upscale: false

--- a/web/config/sync/image.style.small.yml
+++ b/web/config/sync/image.style.small.yml
@@ -1,0 +1,15 @@
+uuid: f83eb818-864c-4193-aa6b-c203d721339a
+langcode: en
+status: true
+dependencies: {  }
+name: small
+label: 'Small (330x330)'
+effects:
+  1a9ce3be-60b0-4ab7-ab0e-92d8bbf52e2b:
+    uuid: 1a9ce3be-60b0-4ab7-ab0e-92d8bbf52e2b
+    id: image_scale
+    weight: 1
+    data:
+      width: 330
+      height: 330
+      upscale: false

--- a/web/config/sync/rest.settings.yml
+++ b/web/config/sync/rest.settings.yml
@@ -2,22 +2,7 @@ resources:
   'entity:node':
     GET:
       supported_formats:
-        - hal_json
-      supported_auth:
-        - basic_auth
-    POST:
-      supported_formats:
-        - hal_json
-      supported_auth:
-        - basic_auth
-    PATCH:
-      supported_formats:
-        - hal_json
-      supported_auth:
-        - basic_auth
-    DELETE:
-      supported_formats:
-        - hal_json
+        - json
       supported_auth:
         - basic_auth
 link_domain: null

--- a/web/modules/custom/dbcdk_community_content/dbcdk_community_content.services.yml
+++ b/web/modules/custom/dbcdk_community_content/dbcdk_community_content.services.yml
@@ -1,0 +1,17 @@
+services:
+  dbcdk_community_content.field_normalizer:
+    class: Drupal\dbcdk_community_content\FieldNormalizer\FieldNormalizer
+  dbcdk_community_content.normalizer.entity_reference_item:
+    class: Drupal\dbcdk_community_content\Normalizer\EntityReferenceFieldItemNormalizer
+    arguments: ['@dbcdk_community_content.field_normalizer']
+    tags:
+      - { name: normalizer, priority: 6 }
+  dbcdk_community_content.normalizer.complex_data:
+    class: Drupal\dbcdk_community_content\Normalizer\ComplexDataNormalizer
+    tags:
+      - { name: normalizer, priority: 6 }
+  dbcdk_community_content.normalizer.content_entity:
+      class: Drupal\dbcdk_community_content\Normalizer\ContentEntityNormalizer
+      arguments: ['@entity.manager']
+      tags:
+        - { name: normalizer, priority: 6 }

--- a/web/modules/custom/dbcdk_community_content/src/FieldNormalizer/FieldNormalizer.php
+++ b/web/modules/custom/dbcdk_community_content/src/FieldNormalizer/FieldNormalizer.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @file
+ * Contains FieldNormalizer.
+ */
+
+namespace Drupal\dbcdk_community_content\FieldNormalizer;
+
+use Drupal\Core\Field\FieldItemBase;
+
+/**
+ * Convert a field into a json-acceptable structure.
+ */
+class FieldNormalizer implements FieldNormalizerInterface {
+
+  /**
+   * The suffix for the field normalizer class names.
+   *
+   * @var string
+   */
+  const SUFFIX = 'FieldNormalizer';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function normalize(FieldItemBase $field) {
+    // Match $field with its corresponding field normalizer.
+    $reflection = new \ReflectionClass($field);
+    $normalizer = __NAMESPACE__ . '\\' . $reflection->getShortName() . self::SUFFIX;
+    if (class_exists($normalizer)) {
+      return (new $normalizer)->normalize($field);
+    }
+    else {
+      throw new \InvalidArgumentException('No field-normalizer available for the field-type' . $reflection->getShortName());
+    }
+  }
+
+}

--- a/web/modules/custom/dbcdk_community_content/src/FieldNormalizer/FieldNormalizerInterface.php
+++ b/web/modules/custom/dbcdk_community_content/src/FieldNormalizer/FieldNormalizerInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @file
+ * Contains FieldNormalizerInterface.
+ */
+
+namespace Drupal\dbcdk_community_content\FieldNormalizer;
+
+use Drupal\Core\Field\FieldItemBase;
+
+/**
+ * Normalize the output for a field object.
+ */
+interface FieldNormalizerInterface {
+
+  /**
+   * Normalize the output for a field object.
+   *
+   * @param \Drupal\Core\Field\FieldItemBase $field
+   *   The field to normalize.
+   *
+   * @return mixed
+   *   The normalized output.
+   */
+  public function normalize(FieldItemBase $field);
+
+}

--- a/web/modules/custom/dbcdk_community_content/src/FieldNormalizer/ImageItemFieldNormalizer.php
+++ b/web/modules/custom/dbcdk_community_content/src/FieldNormalizer/ImageItemFieldNormalizer.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * @file
+ * Contains ImageItemFieldNormalizer.
+ */
+
+namespace Drupal\dbcdk_community_content\FieldNormalizer;
+
+use Drupal\Core\Field\FieldItemBase;
+use Drupal\file\Entity\File;
+use Drupal\image\Entity\ImageStyle;
+
+/**
+ * Normalize the output for an Image field.
+ */
+class ImageItemFieldNormalizer implements FieldNormalizerInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function normalize(FieldItemBase $field) {
+    // Load the file by target_id.
+    /* @var \Drupal\file\Entity\File $image */
+    $image = File::load($field->get('target_id')->getString());
+
+    // Set field values to the output array.
+    $output = [];
+    $output['alt'] = $field->get('alt')->getString();
+    $output['title'] = $field->get('title')->getString();
+    $output['original'] = $image->toUrl()->getUri();
+
+    // Add urls to a processed version of the image.
+    $image_styles = [
+      'thumbnail',
+      'small',
+      'medium',
+      'large',
+    ];
+    foreach ($image_styles as $image_style_name) {
+      /* @var \Drupal\image\Entity\ImageStyle $image_style */
+      $image_style = ImageStyle::load($image_style_name);
+      // ImageStyle::load() will return NULL if the $image_style doesn't exist.
+      if (!empty($image_style)) {
+        // Add the processed image url to the output array.
+        $output[$image_style_name] = $image_style->buildUrl($image->get('uri')->getString());
+      }
+    }
+
+    return $output;
+  }
+
+}

--- a/web/modules/custom/dbcdk_community_content/src/FieldNormalizer/TextLongItemFieldNormalizer.php
+++ b/web/modules/custom/dbcdk_community_content/src/FieldNormalizer/TextLongItemFieldNormalizer.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @file
+ * Contains TextLongItemFieldNormalizer.
+ */
+
+namespace Drupal\dbcdk_community_content\FieldNormalizer;
+
+use Drupal\Core\Field\FieldItemBase;
+
+/**
+ * Normalize the output for a LongText field.
+ */
+class TextLongItemFieldNormalizer implements FieldNormalizerInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function normalize(FieldItemBase $field) {
+    // The TextLongItem value array contains two indexes (text_format & value).
+    // But we only want to return the value.
+    // We also trim to remove any extra "\n" that might exist at the end of the
+    // value since we only should return HTML markup.
+    return trim($field->get('value')->getString());
+  }
+
+}

--- a/web/modules/custom/dbcdk_community_content/src/FieldNormalizer/VideoEmbedFieldFieldNormalizer.php
+++ b/web/modules/custom/dbcdk_community_content/src/FieldNormalizer/VideoEmbedFieldFieldNormalizer.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @file
+ * Contains VideoEmbedFieldFieldNormalizer.
+ */
+
+namespace Drupal\dbcdk_community_content\FieldNormalizer;
+
+use Drupal\Core\Field\FieldItemBase;
+
+/**
+ * Normalize the output for a VideoEmbedField field.
+ */
+class VideoEmbedFieldFieldNormalizer implements FieldNormalizerInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function normalize(FieldItemBase $field) {
+    /* @var \Drupal\video_embed_field\ProviderManager $provider_manager */
+    $provider_manager = \Drupal::service('video_embed_field.provider_manager');
+    /* @var \Drupal\video_embed_field\ProviderPluginBase $provider */
+    $provider = $provider_manager->loadProviderFromInput($field->getString());
+    return [
+      'type' => (new \ReflectionClass($provider))->getShortName(),
+      // It's not possible to strictly fetch the processed embed url, so we have
+      // to call the "renderEmbedCode" method to get a render array and then
+      // cherry pick the ['#url'] property.
+      'url' => $provider->renderEmbedCode(0, 0, FALSE)['#url'],
+    ];
+  }
+
+}

--- a/web/modules/custom/dbcdk_community_content/src/Normalizer/ComplexDataNormalizer.php
+++ b/web/modules/custom/dbcdk_community_content/src/Normalizer/ComplexDataNormalizer.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @file
+ * Contains ComplexDataNormalizer.
+ */
+
+namespace Drupal\dbcdk_community_content\Normalizer;
+
+use Drupal\serialization\Normalizer\ComplexDataNormalizer as SerializationComplexDataNormalizer;
+
+/**
+ * Normalize Drupal entity object structures.
+ *
+ * This is the default Normalizer for entities. All formats that have Encoders
+ * registered with the Serializer in the DIC will be normalized with this
+ * class unless another Normalizer is registered which supersedes it.
+ *
+ * We override the original ComplexDataNormalizer to remove the "value" property
+ * name and just return the value.
+ */
+class ComplexDataNormalizer extends SerializationComplexDataNormalizer {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function normalize($object, $format = NULL, array $context = array()) {
+    return $this->serializer->normalize($object->getString(), $format, $context);
+  }
+
+}

--- a/web/modules/custom/dbcdk_community_content/src/Normalizer/ContentEntityNormalizer.php
+++ b/web/modules/custom/dbcdk_community_content/src/Normalizer/ContentEntityNormalizer.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * @file
+ * Contains ContentEntityNormalizer.
+ */
+
+namespace Drupal\dbcdk_community_content\Normalizer;
+
+use Drupal\serialization\Normalizer\ContentEntityNormalizer as SerializationContentEntityNormalizer;
+
+/**
+ * Normalizes/denormalizes Drupal content entities into an array structure.
+ *
+ * We override the default "ContentEntityNormalizer" to clean up the returned
+ * json object from unnecessary fields and remove all of the array nesting for
+ * single value fields.
+ */
+class ContentEntityNormalizer extends SerializationContentEntityNormalizer {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function normalize($object, $format = NULL, array $context = []) {
+    $context += [
+      'account' => NULL,
+    ];
+
+    $attributes = [];
+    foreach ($object as $name => $field) {
+      $blacklist = [
+        // Ignore unnecessary fields to be normalized.
+        'uuid',
+        'vid',
+        'uid',
+        'revision_timestamp',
+        'revision_uid',
+        'revision_log',
+        'revision_translation_affected',
+        'default_langcode',
+        'path',
+        'field_slug',
+        'field_sub_path',
+      ];
+      if (!in_array($name, $blacklist)) {
+        if ($field->access('view', $context['account'])) {
+          $data = $this->serializer->normalize($field, $format, $context);
+          if (count($data) === 1) {
+            $attributes[$name] = current($data);
+          }
+          else {
+            $attributes[$name] = $data;
+          }
+        }
+      }
+    }
+
+    return $attributes;
+  }
+
+}

--- a/web/modules/custom/dbcdk_community_content/src/Normalizer/EntityReferenceFieldItemNormalizer.php
+++ b/web/modules/custom/dbcdk_community_content/src/Normalizer/EntityReferenceFieldItemNormalizer.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * @file
+ * Contains EntityReferenceFieldItemNormalizer.
+ */
+
+namespace Drupal\dbcdk_community_content\Normalizer;
+
+use Drupal\dbcdk_community_content\FieldNormalizer\FieldNormalizer;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\serialization\Normalizer\EntityReferenceFieldItemNormalizer as SerializationEntityReferenceFieldItemNormalizer;
+
+/**
+ * Converts Drupal entity reference item object to an array structure.
+ *
+ * The reason why we override the original EntityReferenceFieldItemNormalizer is
+ * because we wish to expose the value from a referenced entity instead of the
+ * target id.
+ */
+class EntityReferenceFieldItemNormalizer extends SerializationEntityReferenceFieldItemNormalizer {
+
+  /**
+   * The field normalizer to use on fields.
+   *
+   * @var FieldNormalizer
+   */
+  protected $fieldNormalizer;
+
+  /**
+   * EntityReferenceFieldItemNormalizer constructor.
+   *
+   * @param \Drupal\dbcdk_community_content\FieldNormalizer\FieldNormalizer $field_normalizer
+   *   The field normalizer to use.
+   */
+  public function __construct(FieldNormalizer $field_normalizer) {
+    $this->fieldNormalizer = $field_normalizer;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function normalize($field_item, $format = NULL, array $context = array()) {
+    /* @var \Drupal\Core\Entity\ContentEntityBase $referenced_entity */
+    $referenced_entity = $field_item->get('entity')->getValue();
+    // We only want to alter the normalization of a select few entities, so we
+    // create a blacklist for the parent normalizer to handle everything else.
+    $blacklist = [
+      'paragraph',
+      'taxonomy_term',
+      'node_type',
+    ];
+    if (!in_array($referenced_entity->getEntityTypeId(), $blacklist)) {
+      return parent::normalize($field_item, $format, $context);
+    }
+
+    $output = [];
+    switch ((new \ReflectionClass($referenced_entity))->getShortName()) {
+      // Paragraphs.
+      case 'Paragraph':
+        // Find all custom fields on a paragraph so we can loop through the
+        // fields and call a FieldNormalizer on them.
+        // We find custom fields by looking for "FieldConfig" classes since base
+        // fields on entities are BaseFieldDefinition etc.
+        /* @var \Drupal\field\Entity\FieldConfig $paragraph_fields[] */
+        $paragraph_fields = array_filter($referenced_entity->getFieldDefinitions(), function ($field) {
+          return $field instanceof FieldConfig;
+        });
+
+        // Loop through each "custom field" to get the field normalized.
+        foreach ($paragraph_fields as $nested_fields) {
+          // This field could in theory have multiple values, so this should
+          // possibly be expanded in the future if we wish to support that. But
+          // we, currently, have a Paragraphs architecture that only allows
+          // single values, so we just get the first item.
+          // @TODO Expand this to a loop instead of using "::first()" if we
+          // should support multi-value fields on paragraph entities.
+          /* @var \Drupal\Core\Field\FieldItemBase $nested_field */
+          $nested_field = $referenced_entity->get($nested_fields->getName())->first();
+          $output[$nested_field->getFieldDefinition()->getTargetBundle()] = $this->fieldNormalizer->normalize($nested_field);
+        }
+        break;
+
+      // Taxonomy term.
+      case 'Term':
+        /* @var \Drupal\Taxonomy\Entity\Term $referenced_entity */
+        switch ($field_item->getFieldDefinition()->getName()) {
+          case 'field_article_type':
+            // We wish to return the value of the article_type field instead of
+            // a target_id.
+            $output = $referenced_entity->getName();
+            break;
+
+          // Default back to use the parent normalizer for terms we don't wish
+          // to handle in a special way.
+          default:
+            $output = parent::normalize($field_item, $format, $context);
+            break;
+        }
+        break;
+
+      // Node type.
+      case 'NodeType':
+        /* @var \Drupal\node\Entity\NodeType $referenced_entity */
+        $output = $referenced_entity->get('type');
+        break;
+    }
+
+    return $output;
+  }
+
+}

--- a/web/modules/custom/dbcdk_community_devel/dbcdk_community_devel.info.yml
+++ b/web/modules/custom/dbcdk_community_devel/dbcdk_community_devel.info.yml
@@ -9,3 +9,4 @@ dependencies:
   - field_ui
   - page_manager_ui
   - monolog
+  - restui


### PR DESCRIPTION
This PR contains:
- Add `restui` as part of our devel module
- Update image styles so our exposed images matches biblo.dk's needs.
- Update the REST configuration to only allow [GET] requests.
- Override normalizer services with our own to control the output of the REST requests.
- Core patch to be able to get URL's from file entities.
