### PR TITLE
Use Drupal ruleset from Coder module on Scrutinizer

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,15 +1,4 @@
 tools:
-  php_code_sniffer:
-    extensions:
-      - inc
-      - install
-      - module
-      - php
-      - profile
-      - test
-      - theme
-    config:
-      standard: Drupal
   eslint:
     use_native_config: true
 
@@ -27,6 +16,11 @@ build:
         coverage:
           file: 'tests/reports/clover.xml'
           format: 'php-clover'
+      -
+        command: 'composer phpcs-checkstyle'
+        analysis:
+          file: 'tests/reports/phpcs-checkstyle.xml'
+          format: 'php-cs-checkstyle'
 
 build_failure_conditions:
   # No new issues allowed.

--- a/composer.json
+++ b/composer.json
@@ -53,6 +53,7 @@
         "lint": "vendor/bin/parallel-lint . --exclude vendor --exclude web/core --exclude web/sites/*/files",
         "phpcs": "vendor/bin/phpcs --standard=vendor/drupal/coder/coder_sniffer/Drupal/ruleset.xml --extensions='php,module,inc,install,test,profile,theme,js,css,info,txt' web/modules/custom",
         "phpcs-checkstyle": "vendor/bin/phpcs --standard=vendor/drupal/coder/coder_sniffer/Drupal/ruleset.xml --extensions='php,module,inc,install,test,profile,theme,js,css,info,txt' web/modules/custom --report=checkstyle --report-file=tests/reports/phpcs-checkstyle.xml",
+        "phpcbf": "vendor/bin/phpcbf --standard=vendor/drupal/coder/coder_sniffer/Drupal/ruleset.xml --extensions='php,module,inc,install,test,profile,theme,js,css,info,txt' web/modules/custom",
         "phpunit-drupal": "vendor/bin/phpunit -c web/core/phpunit.xml.dist --testsuite unit --exclude-group Composer --log-junit tests/reports/phpunit-drupal.xml",
         "phpunit-custom": "vendor/bin/phpunit -c tests/phpunit.xml.dist --testsuite unit --log-junit tests/reports/phpunit-custom.xml --coverage-text",
         "phpunit-custom-clover": "vendor/bin/phpunit -c tests/phpunit.xml.dist --testsuite unit --log-junit tests/reports/phpunit-custom.xml --coverage-clover=tests/reports/clover.xml",

--- a/web/modules/custom/dbcdk_community/dbcdk_community.install
+++ b/web/modules/custom/dbcdk_community/dbcdk_community.install
@@ -4,6 +4,8 @@
  * Install, update and uninstall functions for the dbcdk_community module.
  */
 
+use DBCDK\CommunityServices\ApiException;
+
 /**
  * Implements hook_requirements().
  */
@@ -28,7 +30,7 @@ function dbcdk_community_requirements($phase) {
       // actual result is not important here.
       $profile_api->profileFindOne(json_encode(['limit' => 1]));
     }
-    catch (\DBCDK\CommunityServices\ApiException $e) {
+    catch (ApiException $e) {
       // If an exception is thrown then mark requirement as failed and log it.
       $service_requirement['severity'] = REQUIREMENT_ERROR;
       $service_requirement['description'] = $e->getMessage();

--- a/web/modules/custom/dbcdk_community/src/Api/ApiClient.php
+++ b/web/modules/custom/dbcdk_community/src/Api/ApiClient.php
@@ -1,11 +1,8 @@
 <?php
-/**
- * @file
- * ApiClient class definition.
- */
 
 namespace Drupal\dbcdk_community\Api;
 
+use DBCDK\CommunityServices\ApiClient as GeneratedClient;
 use DBCDK\CommunityServices\ApiException;
 
 /**
@@ -13,7 +10,7 @@ use DBCDK\CommunityServices\ApiException;
  *
  * This adds modifications to the generated API client.
  */
-class ApiClient extends \DBCDK\CommunityServices\ApiClient {
+class ApiClient extends GeneratedClient {
 
   /**
    * {@inheritdoc}

--- a/web/modules/custom/dbcdk_community/src/Api/CommunityApiConfiguration.php
+++ b/web/modules/custom/dbcdk_community/src/Api/CommunityApiConfiguration.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\dbcdk_community\CommunityApiConfiguration.
- */
-
 namespace Drupal\dbcdk_community\Api;
 
 use DBCDK\CommunityServices\Configuration as Configuration;

--- a/web/modules/custom/dbcdk_community/src/Form/SettingsForm.php
+++ b/web/modules/custom/dbcdk_community/src/Form/SettingsForm.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\dbcdk_community\Form\SettingsForm.
- */
-
 namespace Drupal\dbcdk_community\Form;
 
 use Drupal\Core\Config\ConfigFactoryInterface;

--- a/web/modules/custom/dbcdk_community/src/Plugin/Block/FormBlock.php
+++ b/web/modules/custom/dbcdk_community/src/Plugin/Block/FormBlock.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * FormBlock definition.
- */
 
 namespace Drupal\dbcdk_community\Plugin\Block;
 

--- a/web/modules/custom/dbcdk_community/src/Url/ModelUrlGenerator.php
+++ b/web/modules/custom/dbcdk_community/src/Url/ModelUrlGenerator.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Class definition for Drupal\dbcdk_community\Url\ModelUrlGenerator.
- */
 
 namespace Drupal\dbcdk_community\Url;
 

--- a/web/modules/custom/dbcdk_community/src/Url/PropertyUrlGenerator.php
+++ b/web/modules/custom/dbcdk_community/src/Url/PropertyUrlGenerator.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Class definition for Drupal\dbcdk_community\Url\PropertyUrlGenerator.
- */
 
 namespace Drupal\dbcdk_community\Url;
 
@@ -29,7 +25,6 @@ class PropertyUrlGenerator implements UrlGeneratorInterface {
   public function __construct($url_pattern) {
     $this->urlPattern = $url_pattern;
   }
-
 
   /**
    * {@inheritdoc}

--- a/web/modules/custom/dbcdk_community/src/Url/UrlGeneratorInterface.php
+++ b/web/modules/custom/dbcdk_community/src/Url/UrlGeneratorInterface.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Class definition for Drupal\dbcdk_community\Url\UrlGenerator.
- */
-
 namespace Drupal\dbcdk_community\Url;
 
 /**

--- a/web/modules/custom/dbcdk_community/tests/src/Unit/Plugin/Block/FormBlockTest.php
+++ b/web/modules/custom/dbcdk_community/tests/src/Unit/Plugin/Block/FormBlockTest.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Test case for FormBlock.
- */
 
 namespace Drupal\Tests\dbcdk_community\Unit\Plugin\Block;
 

--- a/web/modules/custom/dbcdk_community/tests/src/Unit/UnitTestBase.php
+++ b/web/modules/custom/dbcdk_community/tests/src/Unit/UnitTestBase.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Definition of BlockTestBase.
- */
 
 namespace Drupal\Tests\dbcdk_community\Unit;
 

--- a/web/modules/custom/dbcdk_community/tests/src/Unit/Url/ModelUrlGeneratorTest.php
+++ b/web/modules/custom/dbcdk_community/tests/src/Unit/Url/ModelUrlGeneratorTest.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Class definition for Drupal\dbcdk_community\Test\Url|ModelUrlGeneratorTest.
- */
 
 namespace Drupal\dbcdk_community\Test\Url;
 

--- a/web/modules/custom/dbcdk_community_content/src/FieldNormalizer/FieldNormalizer.php
+++ b/web/modules/custom/dbcdk_community_content/src/FieldNormalizer/FieldNormalizer.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains FieldNormalizer.
- */
-
 namespace Drupal\dbcdk_community_content\FieldNormalizer;
 
 use Drupal\Core\Field\FieldItemBase;

--- a/web/modules/custom/dbcdk_community_content/src/FieldNormalizer/FieldNormalizerInterface.php
+++ b/web/modules/custom/dbcdk_community_content/src/FieldNormalizer/FieldNormalizerInterface.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains FieldNormalizerInterface.
- */
-
 namespace Drupal\dbcdk_community_content\FieldNormalizer;
 
 use Drupal\Core\Field\FieldItemBase;

--- a/web/modules/custom/dbcdk_community_content/src/FieldNormalizer/ImageItemFieldNormalizer.php
+++ b/web/modules/custom/dbcdk_community_content/src/FieldNormalizer/ImageItemFieldNormalizer.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains ImageItemFieldNormalizer.
- */
-
 namespace Drupal\dbcdk_community_content\FieldNormalizer;
 
 use Drupal\Core\Field\FieldItemBase;

--- a/web/modules/custom/dbcdk_community_content/src/FieldNormalizer/TextLongItemFieldNormalizer.php
+++ b/web/modules/custom/dbcdk_community_content/src/FieldNormalizer/TextLongItemFieldNormalizer.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains TextLongItemFieldNormalizer.
- */
-
 namespace Drupal\dbcdk_community_content\FieldNormalizer;
 
 use Drupal\Core\Field\FieldItemBase;

--- a/web/modules/custom/dbcdk_community_content/src/FieldNormalizer/VideoEmbedFieldFieldNormalizer.php
+++ b/web/modules/custom/dbcdk_community_content/src/FieldNormalizer/VideoEmbedFieldFieldNormalizer.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains VideoEmbedFieldFieldNormalizer.
- */
-
 namespace Drupal\dbcdk_community_content\FieldNormalizer;
 
 use Drupal\Core\Field\FieldItemBase;

--- a/web/modules/custom/dbcdk_community_content/src/Normalizer/ComplexDataNormalizer.php
+++ b/web/modules/custom/dbcdk_community_content/src/Normalizer/ComplexDataNormalizer.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains ComplexDataNormalizer.
- */
-
 namespace Drupal\dbcdk_community_content\Normalizer;
 
 use Drupal\serialization\Normalizer\ComplexDataNormalizer as SerializationComplexDataNormalizer;

--- a/web/modules/custom/dbcdk_community_content/src/Normalizer/ContentEntityNormalizer.php
+++ b/web/modules/custom/dbcdk_community_content/src/Normalizer/ContentEntityNormalizer.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains ContentEntityNormalizer.
- */
-
 namespace Drupal\dbcdk_community_content\Normalizer;
 
 use Drupal\serialization\Normalizer\ContentEntityNormalizer as SerializationContentEntityNormalizer;

--- a/web/modules/custom/dbcdk_community_content/src/Normalizer/EntityReferenceFieldItemNormalizer.php
+++ b/web/modules/custom/dbcdk_community_content/src/Normalizer/EntityReferenceFieldItemNormalizer.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains EntityReferenceFieldItemNormalizer.
- */
-
 namespace Drupal\dbcdk_community_content\Normalizer;
 
 use Drupal\dbcdk_community_content\FieldNormalizer\FieldNormalizer;

--- a/web/modules/custom/dbcdk_community_devel/src/Command/GenerateCommand.php
+++ b/web/modules/custom/dbcdk_community_devel/src/Command/GenerateCommand.php
@@ -1,12 +1,8 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\dbcdk_community_devel\Command\GenerateCommand.
- */
-
 namespace Drupal\dbcdk_community_devel\Command;
 
+use Faker\Factory;
 use DBCDK\CommunityServices\Model\Comment;
 use DBCDK\CommunityServices\Model\Flag;
 use DBCDK\CommunityServices\Model\ImageCollection;
@@ -15,9 +11,7 @@ use DBCDK\CommunityServices\Model\Profile;
 use DBCDK\CommunityServices\Model\Quarantine;
 use DBCDK\CommunityServices\Model\Review;
 use DBCDK\CommunityServices\Model\VideoCollection;
-use Drupal\Core\KeyValueStore\KeyValueStoreInterface;
 use Drupal\dbcdk_openagency\Client\Branch;
-use Drupal\dbcdk_openagency\Service\AgencyBranchService;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Drupal\Console\Command\Command;
@@ -104,7 +98,7 @@ class GenerateCommand extends Command {
   protected function execute(InputInterface $input, OutputInterface $output) {
     $io = new DrupalStyle($input, $output);
 
-    $faker = \Faker\Factory::create();
+    $faker = Factory::create();
 
     /* @var AgencyBranchService $agency_branch */
     $agency_branch = \Drupal::service('dbcdk_openagency.agency_branch');

--- a/web/modules/custom/dbcdk_community_moderation/dbcdk_community_moderation.module
+++ b/web/modules/custom/dbcdk_community_moderation/dbcdk_community_moderation.module
@@ -4,14 +4,18 @@
  * Module file for DBCDK Community Moderation.
  */
 
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Drupal\Core\Url;
+use Drupal\user\Entity\User;
+
 /**
  * Implements hook_user_login().
  */
-function dbcdk_community_moderation_user_login(\Drupal\user\Entity\User $account) {
+function dbcdk_community_moderation_user_login(User $account) {
   // Redirect moderators to the flagged content list.
   if (in_array('admin_moderator', $account->getRoles())) {
-    $url = new \Drupal\Core\Url('page_manager.page_view_dbcdk_community_flagged_content');
-    $redirect = new \Symfony\Component\HttpFoundation\RedirectResponse($url->toString());
+    $url = new Url('page_manager.page_view_dbcdk_community_flagged_content');
+    $redirect = new RedirectResponse($url->toString());
     $redirect->send();
   }
 }

--- a/web/modules/custom/dbcdk_community_moderation/src/Content/Comment.php
+++ b/web/modules/custom/dbcdk_community_moderation/src/Content/Comment.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Comment class definition.
- */
 
 namespace Drupal\dbcdk_community_moderation\Content;
 

--- a/web/modules/custom/dbcdk_community_moderation/src/Content/FlaggableContentInterface.php
+++ b/web/modules/custom/dbcdk_community_moderation/src/Content/FlaggableContentInterface.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * FlaggableContentInterface definition.
- */
 
 namespace Drupal\dbcdk_community_moderation\Content;
 

--- a/web/modules/custom/dbcdk_community_moderation/src/Content/FlaggableContentRepository.php
+++ b/web/modules/custom/dbcdk_community_moderation/src/Content/FlaggableContentRepository.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * FlaggableContentRepository class definition.
- */
-
 namespace Drupal\dbcdk_community_moderation\Content;
 
 use DBCDK\CommunityServices\Api\CommentApi;
@@ -52,7 +47,6 @@ class FlaggableContentRepository {
    * @var ReviewApi
    */
   protected $reviewApi;
-
 
   /**
    * FlaggableContentRepository constructor.

--- a/web/modules/custom/dbcdk_community_moderation/src/Content/FlaggableTrait.php
+++ b/web/modules/custom/dbcdk_community_moderation/src/Content/FlaggableTrait.php
@@ -1,14 +1,14 @@
 <?php
-/**
- * @file
- * FlaggableTrait definition.
- */
 
 namespace Drupal\dbcdk_community_moderation\Content;
 
 use DBCDK\CommunityServices\Model\Flag;
 
+/**
+ * Trait for content classes that can be flagged for moderation.
+ */
 trait FlaggableTrait {
+
   /**
    * The flags attached to the content.
    *

--- a/web/modules/custom/dbcdk_community_moderation/src/Content/Post.php
+++ b/web/modules/custom/dbcdk_community_moderation/src/Content/Post.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Post class definition.
- */
 
 namespace Drupal\dbcdk_community_moderation\Content;
 

--- a/web/modules/custom/dbcdk_community_moderation/src/Content/Review.php
+++ b/web/modules/custom/dbcdk_community_moderation/src/Content/Review.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Review class definition.
- */
 
 namespace Drupal\dbcdk_community_moderation\Content;
 

--- a/web/modules/custom/dbcdk_community_moderation/src/Form/FlagsMarkReadForm.php
+++ b/web/modules/custom/dbcdk_community_moderation/src/Form/FlagsMarkReadForm.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Class definition for FlagsMarkReadForm.
- */
 
 namespace Drupal\dbcdk_community_moderation\Form;
 

--- a/web/modules/custom/dbcdk_community_moderation/src/Form/ProfileEditForm.php
+++ b/web/modules/custom/dbcdk_community_moderation/src/Form/ProfileEditForm.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\dbcdk_community_moderation\Form\ProfileEditForm.
- */
-
 namespace Drupal\dbcdk_community_moderation\Form;
 
 use DBCDK\CommunityServices\ApiException;

--- a/web/modules/custom/dbcdk_community_moderation/src/Form/ProfilesFilterForm.php
+++ b/web/modules/custom/dbcdk_community_moderation/src/Form/ProfilesFilterForm.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\dbcdk_community_moderation\Form\ProfilesFilterForm.
- */
-
 namespace Drupal\dbcdk_community_moderation\Form;
 
 use Drupal\Core\Form\FormBase;

--- a/web/modules/custom/dbcdk_community_moderation/src/Form/QuarantineForm.php
+++ b/web/modules/custom/dbcdk_community_moderation/src/Form/QuarantineForm.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\dbcdk_community_moderation\Form\QuarantineForm.
- */
-
 namespace Drupal\dbcdk_community_moderation\Form;
 
 use DBCDK\CommunityServices\Api\QuarantineApi;

--- a/web/modules/custom/dbcdk_community_moderation/src/Form/ReviewListForm.php
+++ b/web/modules/custom/dbcdk_community_moderation/src/Form/ReviewListForm.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Class definition for review lists.
- */
 
 namespace Drupal\dbcdk_community_moderation\Form;
 
@@ -41,7 +37,7 @@ class ReviewListForm extends FormBase {
   protected $urlGenerator;
 
   /**
-   * The review api to use for retrieving reviews
+   * The review api to use for retrieving reviews.
    *
    * @var ReviewApi
    */

--- a/web/modules/custom/dbcdk_community_moderation/src/Plugin/Block/FlaggedContentDetailsBlock.php
+++ b/web/modules/custom/dbcdk_community_moderation/src/Plugin/Block/FlaggedContentDetailsBlock.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\dbcdk_community\Plugin\Block\FlaggedContentDetails.
- */
-
 namespace Drupal\dbcdk_community_moderation\Plugin\Block;
 
 use DBCDK\CommunityServices\Api\ProfileApi;

--- a/web/modules/custom/dbcdk_community_moderation/src/Plugin/Block/FlaggedContentFlagListBlock.php
+++ b/web/modules/custom/dbcdk_community_moderation/src/Plugin/Block/FlaggedContentFlagListBlock.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\dbcdk_community\Plugin\Block\FlaggedContentFlagList.
- */
-
 namespace Drupal\dbcdk_community_moderation\Plugin\Block;
 
 use DBCDK\CommunityServices\ApiException;

--- a/web/modules/custom/dbcdk_community_moderation/src/Plugin/Block/FlaggedContentList.php
+++ b/web/modules/custom/dbcdk_community_moderation/src/Plugin/Block/FlaggedContentList.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * FlaggedContentList class definition.
- */
-
 namespace Drupal\dbcdk_community_moderation\Plugin\Block;
 
 use DBCDK\CommunityServices\ApiException;

--- a/web/modules/custom/dbcdk_community_moderation/src/Plugin/Block/ProfileBlock.php
+++ b/web/modules/custom/dbcdk_community_moderation/src/Plugin/Block/ProfileBlock.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\dbcdk_community\Plugin\Block\ProfileBlock.
- */
-
 namespace Drupal\dbcdk_community_moderation\Plugin\Block;
 
 use DBCDK\CommunityServices\Model\CommunityRole;

--- a/web/modules/custom/dbcdk_community_moderation/src/Plugin/Block/ProfileQuarantinesBlock.php
+++ b/web/modules/custom/dbcdk_community_moderation/src/Plugin/Block/ProfileQuarantinesBlock.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains ProfileQuarantinesBlock.
- */
-
 namespace Drupal\dbcdk_community_moderation\Plugin\Block;
 
 use DBCDK\CommunityServices\ApiException;

--- a/web/modules/custom/dbcdk_community_moderation/src/Plugin/Block/ProfilesBlock.php
+++ b/web/modules/custom/dbcdk_community_moderation/src/Plugin/Block/ProfilesBlock.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\dbcdk_community_moderation\Plugin\Block\ProfilesBlock.
- */
-
 namespace Drupal\dbcdk_community_moderation\Plugin\Block;
 
 use DateTime;

--- a/web/modules/custom/dbcdk_community_moderation/src/Profile/Profile.php
+++ b/web/modules/custom/dbcdk_community_moderation/src/Profile/Profile.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Class definition for Profiles.
- */
 
 namespace Drupal\dbcdk_community_moderation\Profile;
 

--- a/web/modules/custom/dbcdk_community_moderation/src/Profile/ProfileRepository.php
+++ b/web/modules/custom/dbcdk_community_moderation/src/Profile/ProfileRepository.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Class definition for ProfileRepository.
- */
 
 namespace Drupal\dbcdk_community_moderation\Profile;
 

--- a/web/modules/custom/dbcdk_community_moderation/tests/src/Unit/Content/FlaggableContentRepositoryTest.php
+++ b/web/modules/custom/dbcdk_community_moderation/tests/src/Unit/Content/FlaggableContentRepositoryTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * FlaggableContentRepositoryTest class definition.
- */
-
 namespace Drupal\dbcdk_community\Test\Content;
 
 use DBCDK\CommunityServices\ApiException;

--- a/web/modules/custom/dbcdk_community_moderation/tests/src/Unit/Content/FlaggableContentTest.php
+++ b/web/modules/custom/dbcdk_community_moderation/tests/src/Unit/Content/FlaggableContentTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * FlaggableContentTest class definition.
- */
-
 namespace Drupal\dbcdk_community\Test\Content;
 
 use DateTime;

--- a/web/modules/custom/dbcdk_community_moderation/tests/src/Unit/Form/ReviewListFormTest.php
+++ b/web/modules/custom/dbcdk_community_moderation/tests/src/Unit/Form/ReviewListFormTest.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Test case for ReviewListForm.
- */
 
 namespace Drupal\dbcdk_community_moderation\Test\Unit\Form;
 
@@ -106,7 +102,11 @@ class ReviewListFormTest extends UnitTestBase {
     $this->reviewApi
       ->expects($this->once())
       ->method('reviewFind')
-      ->with(json_encode(['where' => ['libraryid' => ['inq' => [$library_id]]], 'offset' => 0, 'limit' => 10]));
+      ->with(json_encode([
+        'where' => ['libraryid' => ['inq' => [$library_id]]],
+        'offset' => 0,
+        'limit' => 10,
+      ]));
 
     $form = $this->newReviewListForm();
     $form->buildForm([], $form_state);

--- a/web/modules/custom/dbcdk_community_moderation/tests/src/Unit/Plugin/Block/FlaggedContentDetailsBlockTest.php
+++ b/web/modules/custom/dbcdk_community_moderation/tests/src/Unit/Plugin/Block/FlaggedContentDetailsBlockTest.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Definition of FlaggedContentDetailsBlockTest.
- */
 
 namespace Drupal\Tests\dbcdk_community_moderation\Unit\Plugin\Block;
 

--- a/web/modules/custom/dbcdk_community_moderation/tests/src/Unit/Plugin/Block/FlaggedContentListTest.php
+++ b/web/modules/custom/dbcdk_community_moderation/tests/src/Unit/Plugin/Block/FlaggedContentListTest.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Definition of FlaggedContentListTest.
- */
 
 namespace Drupal\Tests\dbcdk_community_moderation\Unit\Plugin\Block;
 

--- a/web/modules/custom/dbcdk_community_moderation/tests/src/Unit/Plugin/Block/ProfileBlockTest.php
+++ b/web/modules/custom/dbcdk_community_moderation/tests/src/Unit/Plugin/Block/ProfileBlockTest.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Definition of ProfileBlockTest.
- */
 
 namespace Drupal\Tests\dbcdk_community_moderation\Unit\Plugin\Block;
 

--- a/web/modules/custom/dbcdk_community_moderation/tests/src/Unit/Plugin/Block/ProfileQuarantinesBlockTest.php
+++ b/web/modules/custom/dbcdk_community_moderation/tests/src/Unit/Plugin/Block/ProfileQuarantinesBlockTest.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Definition of ProfileQuarantinesBlockTest.
- */
 
 namespace Drupal\Tests\dbcdk_community_moderation\Unit\Plugin\Block;
 

--- a/web/modules/custom/dbcdk_community_moderation/tests/src/Unit/Plugin/Block/ProfilesBlockTest.php
+++ b/web/modules/custom/dbcdk_community_moderation/tests/src/Unit/Plugin/Block/ProfilesBlockTest.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Definition of ProfilesBlockTest.
- */
 
 namespace Drupal\Tests\dbcdk_community_moderation\Unit\Plugin\Block;
 

--- a/web/modules/custom/dbcdk_community_moderation/tests/src/Unit/Profile/ProfileRepositoryTest.php
+++ b/web/modules/custom/dbcdk_community_moderation/tests/src/Unit/Profile/ProfileRepositoryTest.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Test case for ProfileRepository.
- */
 
 namespace Drupal\dbcdk_community_moderation\Test\Content;
 

--- a/web/modules/custom/dbcdk_openagency/dbcdk_openagency.install
+++ b/web/modules/custom/dbcdk_openagency/dbcdk_openagency.install
@@ -3,6 +3,7 @@
  * @file
  * Install file for DBCDK OpenAgency module.
  */
+
 use Drupal\dbcdk_openagency\Client\Service;
 
 /**

--- a/web/modules/custom/dbcdk_openagency/src/Client/Agency.php
+++ b/web/modules/custom/dbcdk_openagency/src/Client/Agency.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Agency class definition.
- */
 
 namespace Drupal\dbcdk_openagency\Client;
 

--- a/web/modules/custom/dbcdk_openagency/src/Client/Branch.php
+++ b/web/modules/custom/dbcdk_openagency/src/Client/Branch.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Branch class definition.
- */
 
 namespace Drupal\dbcdk_openagency\Client;
 

--- a/web/modules/custom/dbcdk_openagency/src/Client/PickupAgencyListResponse.php
+++ b/web/modules/custom/dbcdk_openagency/src/Client/PickupAgencyListResponse.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * PickupAgencyListResponse class definition.
- */
 
 namespace Drupal\dbcdk_openagency\Client;
 

--- a/web/modules/custom/dbcdk_openagency/src/Client/Service.php
+++ b/web/modules/custom/dbcdk_openagency/src/Client/Service.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Service class definition.
- */
 
 namespace Drupal\dbcdk_openagency\Client;
 

--- a/web/modules/custom/dbcdk_openagency/src/Form/AdminForm.php
+++ b/web/modules/custom/dbcdk_openagency/src/Form/AdminForm.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * AdminForm class definition.
- */
 
 namespace Drupal\dbcdk_openagency\Form;
 

--- a/web/modules/custom/dbcdk_openagency/src/Plugin/QueueWorker/AgencyFetcher.php
+++ b/web/modules/custom/dbcdk_openagency/src/Plugin/QueueWorker/AgencyFetcher.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * AgencyFetcher class definition.
- */
 
 namespace Drupal\dbcdk_openagency\Plugin\QueueWorker;
 

--- a/web/modules/custom/dbcdk_openagency/src/Plugin/QueueWorker/AgencyProcessor.php
+++ b/web/modules/custom/dbcdk_openagency/src/Plugin/QueueWorker/AgencyProcessor.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * AgencyProcessor class definition.
- */
 
 namespace Drupal\dbcdk_openagency\Plugin\QueueWorker;
 

--- a/web/modules/custom/dbcdk_openagency/src/Service/AgencyBranchService.php
+++ b/web/modules/custom/dbcdk_openagency/src/Service/AgencyBranchService.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * AgencyBranchService class definition.
- */
 
 namespace Drupal\dbcdk_openagency\Service;
 


### PR DESCRIPTION
This means we have to configure the analysis as a part of the build -
not as a tool.

See https://scrutinizer-ci.com/docs/tools/php/code-sniffer/
