### PR TITLE
#543: New role: Library employee

### DIFF
--- a/web/config/sync/system.action.user_add_role_action.admin_library_employee.yml
+++ b/web/config/sync/system.action.user_add_role_action.admin_library_employee.yml
@@ -1,0 +1,14 @@
+uuid: 2bd317a2-0bfb-495b-879c-3bc3ce84ecf7
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.admin_library_employee
+  module:
+    - user
+id: user_add_role_action.admin_library_employee
+label: 'Add the Library employee role to the selected users'
+type: user
+plugin: user_add_role_action
+configuration:
+  rid: admin_library_employee

--- a/web/config/sync/system.action.user_remove_role_action.admin_library_employee.yml
+++ b/web/config/sync/system.action.user_remove_role_action.admin_library_employee.yml
@@ -1,0 +1,14 @@
+uuid: e2060c76-782c-4588-bc9b-47a9bd1f22e7
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.admin_library_employee
+  module:
+    - user
+id: user_remove_role_action.admin_library_employee
+label: 'Remove the Library employee role from the selected users'
+type: user
+plugin: user_remove_role_action
+configuration:
+  rid: admin_library_employee

--- a/web/config/sync/user.role.admin_library_employee.yml
+++ b/web/config/sync/user.role.admin_library_employee.yml
@@ -1,0 +1,10 @@
+uuid: b598b954-c1e9-4a6f-a098-fafac21b0671
+langcode: en
+status: true
+dependencies: {  }
+id: admin_library_employee
+label: 'Library employee'
+weight: 5
+is_admin: null
+permissions:
+  - 'dbcdk community view reviews'

--- a/web/modules/custom/dbcdk_community/dbcdk_community.module
+++ b/web/modules/custom/dbcdk_community/dbcdk_community.module
@@ -4,6 +4,35 @@
  * Module file for DBCDK Community.
  */
 
+use Drupal\Core\Url;
+use Drupal\user\Entity\User;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+/**
+ * Implements hook_user_login().
+ */
+function dbcdk_community_user_login(User $account) {
+  // Redirect roles with specific focus to their primary page on login.
+  // Map each role to the corresponding path. First roles take precedence in
+  // case a user has multiple roles.
+  $role_route_map = [
+    'admin_moderator' => 'page_manager.page_view_dbcdk_community_flagged_content',
+    'admin_library_employee' => 'page_manager.page_view_dbcdk_community_reviews',
+    'admin_editor' => 'system.admin_content',
+  ];
+  $user_role_routes = array_intersect_key(
+    $role_route_map,
+    // We need the role names as keys to do an intersect.
+    array_flip($account->getRoles())
+  );
+  $route = array_shift($user_role_routes);
+  if (!empty($route)) {
+    $url = new Url($route);
+    $redirect = new RedirectResponse($url->toString());
+    $redirect->send();
+  }
+}
+
 /**
  * Implements hook_element_info_alter().
  *

--- a/web/modules/custom/dbcdk_community_moderation/dbcdk_community_moderation.module
+++ b/web/modules/custom/dbcdk_community_moderation/dbcdk_community_moderation.module
@@ -4,22 +4,6 @@
  * Module file for DBCDK Community Moderation.
  */
 
-use Symfony\Component\HttpFoundation\RedirectResponse;
-use Drupal\Core\Url;
-use Drupal\user\Entity\User;
-
-/**
- * Implements hook_user_login().
- */
-function dbcdk_community_moderation_user_login(User $account) {
-  // Redirect moderators to the flagged content list.
-  if (in_array('admin_moderator', $account->getRoles())) {
-    $url = new Url('page_manager.page_view_dbcdk_community_flagged_content');
-    $redirect = new RedirectResponse($url->toString());
-    $redirect->send();
-  }
-}
-
 /**
  * Implements hook_theme().
  */


### PR DESCRIPTION
Library employees are general users who are primarily concerned about
how users related to their library are using the site.

We do not enforce relationships between users and libraries at the 
moment though.

Currently library users can only access the review list so redirect them here 
on login
