### PR TITLE
Add new full HTML text format + editor

### DIFF
--- a/web/config/sync/editor.editor.dbcdk_community_full_html.yml
+++ b/web/config/sync/editor.editor.dbcdk_community_full_html.yml
@@ -1,0 +1,50 @@
+uuid: 4491e2ae-de0c-4cc8-b047-ea514595f7cf
+langcode: en
+status: true
+dependencies:
+  config:
+    - filter.format.dbcdk_community_full_html
+  module:
+    - ckeditor
+format: dbcdk_community_full_html
+editor: ckeditor
+settings:
+  toolbar:
+    rows:
+      -
+        -
+          name: Formatting
+          items:
+            - Format
+            - Bold
+            - Italic
+            - Underline
+        -
+          name: Links
+          items:
+            - DrupalLink
+            - DrupalUnlink
+        -
+          name: Lists
+          items:
+            - BulletedList
+            - NumberedList
+        -
+          name: Tools
+          items:
+            - Source
+            - RemoveFormat
+            - PasteFromWord
+  plugins:
+    language:
+      language_list: un
+    stylescombo:
+      styles: ''
+image_upload:
+  status: false
+  scheme: public
+  directory: inline-images
+  max_size: ''
+  max_dimensions:
+    width: null
+    height: null

--- a/web/config/sync/filter.format.dbcdk_community_basic_markup.yml
+++ b/web/config/sync/filter.format.dbcdk_community_basic_markup.yml
@@ -4,7 +4,7 @@ status: true
 dependencies: {  }
 name: 'DBCDK Community - Basic markup'
 format: dbcdk_community_basic_markup
-weight: -10
+weight: -9
 filters:
   filter_autop:
     id: filter_autop

--- a/web/config/sync/filter.format.dbcdk_community_full_html.yml
+++ b/web/config/sync/filter.format.dbcdk_community_full_html.yml
@@ -1,0 +1,68 @@
+uuid: cefbc865-b5d8-42d2-8584-98fb99d5809c
+langcode: en
+status: true
+dependencies:
+  module:
+    - editor
+name: 'DBCDK Community - Full HTML'
+format: dbcdk_community_full_html
+weight: -10
+filters:
+  filter_autop:
+    id: filter_autop
+    provider: filter
+    status: true
+    weight: -49
+    settings: {  }
+  editor_file_reference:
+    id: editor_file_reference
+    provider: editor
+    status: false
+    weight: -47
+    settings: {  }
+  filter_align:
+    id: filter_align
+    provider: filter
+    status: false
+    weight: -46
+    settings: {  }
+  filter_caption:
+    id: filter_caption
+    provider: filter
+    status: false
+    weight: -45
+    settings: {  }
+  filter_html:
+    id: filter_html
+    provider: filter
+    status: true
+    weight: -50
+    settings:
+      allowed_html: '<a href hreflang> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id><h4 id> <p> <u>'
+      filter_html_help: true
+      filter_html_nofollow: false
+  filter_htmlcorrector:
+    id: filter_htmlcorrector
+    provider: filter
+    status: false
+    weight: -42
+    settings: {  }
+  filter_html_escape:
+    id: filter_html_escape
+    provider: filter
+    status: false
+    weight: -48
+    settings: {  }
+  filter_html_image_secure:
+    id: filter_html_image_secure
+    provider: filter
+    status: false
+    weight: -43
+    settings: {  }
+  filter_url:
+    id: filter_url
+    provider: filter
+    status: false
+    weight: -44
+    settings:
+      filter_url_length: 72

--- a/web/config/sync/filter.format.plain_text.yml
+++ b/web/config/sync/filter.format.plain_text.yml
@@ -6,7 +6,7 @@ _core:
   default_config_hash: NIKBt6kw_uPhNI0qtR2DnRf7mSOgAQdx7Q94SKMjXbQ
 name: 'Plain text'
 format: plain_text
-weight: -9
+weight: -8
 filters:
   filter_html_escape:
     id: filter_html_escape

--- a/web/config/sync/user.role.admin_editor.yml
+++ b/web/config/sync/user.role.admin_editor.yml
@@ -19,3 +19,4 @@ permissions:
   - 'edit own article content'
   - 'revert article revisions'
   - 'view article revisions'
+  - 'use text format dbcdk_community_full_html'


### PR DESCRIPTION
Editors want extended capabilities when working with articles. This new
format has more buttons in the editor and in essence allows full HTML.

A few block formats (h1, h5-6) are not allowed as we do not want them to
show up in the editor either.
