### PR TITLE
Admin content should link to the community site.

### DIFF
--- a/web/modules/custom/dbcdk_community_content/dbcdk_community_content.module
+++ b/web/modules/custom/dbcdk_community_content/dbcdk_community_content.module
@@ -6,6 +6,7 @@
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\Url;
 use Drupal\node\Entity\Node;
 
 /**
@@ -46,7 +47,32 @@ function dbcdk_community_content_form_alter(&$form, FormStateInterface $form_sta
           $form[$field_name]['#group'] = $url_group_name;
         }
       }
+
+      // Append new submit handler for when a node is being saved (which is
+      // triggered by the publish and unpublish actions).
+      $form['actions']['publish']['#submit'][] = 'dbcdk_community_content_node_submit_handler';
+      $form['actions']['unpublish']['#submit'][] = 'dbcdk_community_content_node_submit_handler';
       break;
+  }
+}
+
+/**
+ * Custom submit handler for nodes.
+ *
+ * Redirect the user to the content overview page after a node submit.
+ * We do this because all "node/{node}" paths are being redirected to the
+ * community site.
+ * This does not have any effect on REST requests (node/{nid}?_format=...).
+ */
+function dbcdk_community_content_node_submit_handler(&$form, FormStateInterface $form_state) {
+  // Redirect to the content overview route unless there is a "destination"
+  // parameter.
+  $destination = \Drupal::request()->query->get('destination');
+  if (!empty($destination)) {
+    $form_state->setRedirectUrl(Url::fromUserInput($destination));
+  }
+  else {
+    $form_state->setRedirect('system.admin_content');
   }
 }
 

--- a/web/modules/custom/dbcdk_community_content/dbcdk_community_content.module
+++ b/web/modules/custom/dbcdk_community_content/dbcdk_community_content.module
@@ -8,6 +8,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 use Drupal\node\Entity\Node;
+use Drupal\views\Plugin\views\field\Field;
 
 /**
  * Implements hook_node_presave().
@@ -21,6 +22,35 @@ function dbcdk_community_content_node_presave(Node $node) {
     /* @var \Drupal\pathauto\AliasCleaner $alias_cleaner */
     $alias_cleaner = \Drupal::service('pathauto.alias_cleaner');
     $node->set('field_slug', $alias_cleaner->cleanString($node->getTitle()));
+  }
+}
+
+/**
+ * Implements template_preprocess_views_view_field().
+ *
+ * Add a "target" property to the title-link render array.
+ * We do this because all "node/{nid}" matches are redirected to the community
+ * site and we wish to open all external links in a new window.
+ */
+function dbcdk_community_content_preprocess_views_view_field(&$variables) {
+  // Defensive code to make sure it's a Field object we try to manipulate.
+  // Other objects include but is not necessarily limited to: NodeBulkUpdate.
+  /* @var \Drupal\views\Plugin\views\field\Field $field */
+  if (($field = $variables['field']) instanceof Field) {
+    // These changes should only happen on the title field on the content view.
+    if (($field->field === 'title') && ($variables['view']->id() === 'content')) {
+      // Get the title render array.
+      $link = current($field->getItems($variables['row']))['rendered'];
+      // Add "target" property to the link render array.
+      $link['#attributes']['target'] = '_blank';
+      // It is possible to call the renderer with $field->render_item() method
+      // but it seems unstable (a method without DocBlock and unused parameters
+      // inside the method).
+      $renderer = \Drupal::service('renderer');
+      // Override the "output" variable for the views-view-field template with a
+      // new, rendered, link item.
+      $variables['output'] = $renderer->render($link);
+    }
   }
 }
 

--- a/web/modules/custom/dbcdk_community_content/dbcdk_community_content.routing.yml
+++ b/web/modules/custom/dbcdk_community_content/dbcdk_community_content.routing.yml
@@ -1,0 +1,7 @@
+# Take control of the node view path.
+dbcdk_community_content.node.view:
+  path: '/node/{nid}'
+  defaults:
+    _controller: '\Drupal\dbcdk_community_content\Controller\NodeController::communityRedirect'
+  requirements:
+    _permission: 'access content'

--- a/web/modules/custom/dbcdk_community_content/src/Controller/NodeController.php
+++ b/web/modules/custom/dbcdk_community_content/src/Controller/NodeController.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Drupal\dbcdk_community_content\Controller;
+
+use Drupal\Core\Config\Config;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Routing\TrustedRedirectResponse;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Returns responses for Node routes.
+ *
+ * This NodeController is only used for the "node/{nid}" route and is called in
+ * this modules routing.yml file.
+ */
+class NodeController implements ContainerInjectionInterface {
+
+  /**
+   * The community settings object.
+   *
+   * @var \Drupal\Core\Config\Config
+   */
+  protected $communitySettings;
+
+  /**
+   * THe current request object.
+   *
+   * @var \Symfony\Component\HttpFoundation\Request
+   */
+  protected $currentRequest;
+
+  /**
+   * NodeController constructor.
+   *
+   * @param \Drupal\Core\Config\Config $community_settings
+   *   The community settings object.
+   * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
+   *   The request stack.
+   */
+  public function __construct(Config $community_settings, RequestStack $request_stack) {
+    $this->communitySettings = $community_settings;
+    $this->currentRequest = $request_stack->getCurrentRequest();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory')->get('dbcdk_community.settings'),
+      $container->get('request_stack')
+    );
+  }
+
+  /**
+   * Redirect node views to the community site.
+   *
+   * Redirect all node/{nid} paths to the community site so administrators can
+   * be presented to their creations.
+   *
+   * @return \Drupal\Core\Routing\TrustedRedirectResponse
+   *   A trusted redirect object forwarding to the community site.
+   */
+  public function communityRedirect() {
+    return new TrustedRedirectResponse($this->communitySettings->get('community_site_url') . $this->currentRequest->getRequestUri());
+  }
+
+}

--- a/web/modules/custom/dbcdk_community_content/tests/src/Unit/Controller/NodeControllerTest.php
+++ b/web/modules/custom/dbcdk_community_content/tests/src/Unit/Controller/NodeControllerTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Drupal\dbcdk_community_content\Test\Unit\Controller;
+
+use Drupal\dbcdk_community_content\Controller\NodeController;
+use Drupal\Tests\dbcdk_community\Unit\UnitTestBase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Test case for NodeController.
+ *
+ * @group dbcdk_community_content
+ */
+class NodeControllerTest extends UnitTestBase {
+
+  /* @var \PHPUnit_Framework_MockObject_MockObject */
+  protected $communityConfiguration;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+
+    $this->communityConfiguration = $this->getMockBuilder(
+      '\Drupal\Core\Config\Config'
+    )->disableOriginalConstructor()->getMock();
+  }
+
+  /**
+   * Test Community Redirect method.
+   */
+  public function testCommunityRedirect() {
+    // Data.
+    $community_site_url = 'http://biblo.dk';
+    $drupal_relative_path = '/example/relative/path';
+
+    // Node Controller.
+    $this->communityConfiguration->method('get')->willReturnMap([['community_site_url', $community_site_url]]);
+    $request_stack = new RequestStack();
+    $request_stack->push(Request::create($drupal_relative_path));
+    $controller = new NodeController($this->communityConfiguration, $request_stack);
+    $redirect = $controller->communityRedirect();
+
+    // Assertion.
+    $this->assertEquals($community_site_url . $drupal_relative_path, $redirect->getTargetUrl());
+  }
+
+}


### PR DESCRIPTION
The ticket was to create a link from the content overview list to the community site.
I have chosen to go down the path of forwarding all "node/{nid}" requests to the community site since we don't handle any kind of front-end rendering and the existence of a "half view" of the node could cause confusion for some editors/librarians.
This solves the original issue by redirecting the already existing title-link to _"/awesome-content"_ to _"http://biblo.dk/awesome-content"_. (OBS: This does not effect REST requests).

**So this PR does the following:**
- Redirect all "node/{nid}" pages to the community site.
- Redirect users to the "admin/content" path after Node edits/creations (this was the default behaviour if you did not access the edit-page from the "admin/content" route and had a destination parameter in the query).
- Open the "Title" link on the "Content" view in a new window.
