### PR TITLE
Maintain review filtering across pagination

### DIFF
--- a/web/modules/custom/dbcdk_community_moderation/src/Form/ReviewListForm.php
+++ b/web/modules/custom/dbcdk_community_moderation/src/Form/ReviewListForm.php
@@ -108,14 +108,7 @@ class ReviewListForm extends FormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-    // Get the user submitted values without Drupals extras.
-    // As we use form rebuild these have to be retrieved as user input - not
-    // values.
-    $input = $form_state->getUserInput();
-    $input = array_diff_key(
-      $input,
-      ['op' => 1, 'form_build_id' => 1, 'form_token' => 1]
-    );
+    $input = $this->getRequest()->query->all();
 
     $form['filter'] = [
       '#type' => 'details',
@@ -260,9 +253,14 @@ class ReviewListForm extends FormBase {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
-    // Rebuild the form to perform the actual filtering. There is nothing to
-    // submit as such.
-    $form_state->setRebuild(TRUE);
+    // Get the filter values and remove any Drupal extras.
+    $input = array_filter(array_diff_key(
+      $form_state->getValues(),
+      array_flip(['op', 'form_id', 'form_build_id', 'form_token'])
+    ));
+    // Replace filter values into url query to pass them back to the form build
+    // process.
+    $this->getRequest()->query->replace($input);
   }
 
 }

--- a/web/modules/custom/dbcdk_community_moderation/tests/src/Unit/Form/ReviewListFormTest.php
+++ b/web/modules/custom/dbcdk_community_moderation/tests/src/Unit/Form/ReviewListFormTest.php
@@ -9,6 +9,8 @@ use DBCDK\CommunityServices\Model\Review;
 use Drupal\Core\Form\FormState;
 use Drupal\dbcdk_community_moderation\Form\ReviewListForm;
 use Drupal\Tests\dbcdk_community\Unit\UnitTestBase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Test case for ReviewListForm.
@@ -89,7 +91,6 @@ class ReviewListFormTest extends UnitTestBase {
    */
   public function testLibraryFilter() {
     $library_id = '1';
-    $form_state = (new FormState())->setUserInput(['library_id' => $library_id]);
 
     // With a library id set we should only count reviews with that id.
     $this->reviewApi
@@ -115,7 +116,12 @@ class ReviewListFormTest extends UnitTestBase {
       ]));
 
     $form = $this->newReviewListForm();
-    $form->buildForm([], $form_state);
+
+    $request_stack = new RequestStack();
+    $request_stack->push(new Request(['library_id' => $library_id]));
+    $form->setRequestStack($request_stack);
+
+    $form->buildForm([], new FormState());
   }
 
   /**
@@ -223,6 +229,11 @@ class ReviewListFormTest extends UnitTestBase {
       $this->agencyBranchService
     );
     $form->setStringTranslation($this->translation);
+
+    $request_stack = new RequestStack();
+    $request_stack->push(new Request());
+    $form->setRequestStack($request_stack);
+
     return $form;
   }
 


### PR DESCRIPTION
Logic for extracting filter values is moved from build to submit and 
actual values are stored as query parameters.

There is no reason to rebuild the form. Not adding any redirect to
submit handler will ensure that the user stays on the same form / page.

Update tests accordingly.

This fixes #117.
