### PR TITLE
Fix handling of reviews where markedAsDeleted = NULL

### DIFF
--- a/web/modules/custom/dbcdk_community_devel/src/Command/GenerateCommand.php
+++ b/web/modules/custom/dbcdk_community_devel/src/Command/GenerateCommand.php
@@ -193,7 +193,9 @@ class GenerateCommand extends Command {
       $review = new Review();
       $review->setContent($faker->paragraphs());
       $review->setRating($faker->numberBetween(1, 5));
-      $review->setMarkedAsDeleted($faker->randomElement([TRUE, FALSE]));
+      // Marked as deleted support NULL, TRUE and FALSE
+      // Use optional with weight to aim for 1/3 NULL, 1/3 TRUE and 1/3 FALSE.
+      $review->setMarkedAsDeleted($faker->optional(0.67)->randomElement([TRUE, FALSE]));
       $review->setLibraryid($faker->randomElement($branch_ids));
       $review->setPid($faker->randomLetter);
       $review->setWorktype($faker->randomLetter);

--- a/web/modules/custom/dbcdk_community_moderation/src/Form/ReviewListForm.php
+++ b/web/modules/custom/dbcdk_community_moderation/src/Form/ReviewListForm.php
@@ -139,10 +139,14 @@ class ReviewListForm extends FormBase {
     ];
 
     $filter = new \stdClass();
-    // Make sure we only get existing reviews.
-    // We fetch values that are NOT True since the service also contains reviews
-    // that are marked as Null.
-    $filter->markedAsDeleted = ['neq' => TRUE];
+    // Make sure we only get reviews that have not been deleted.
+    // markedAsDeleted support TRUE, FALSE and NULL. In this regard not deleted
+    // is regarded as NULL or FALSE. Use an OR filter as INQ and NEQ operators
+    // do not support NULL properly.
+    $filter->or = [
+      ['markedAsDeleted' => NULL],
+      ['markedAsDeleted' => FALSE],
+    ];
     // User-input filters.
     if (!empty($input['library_id'])) {
       $library_ids = explode(',', $input['library_id']);

--- a/web/modules/custom/dbcdk_community_moderation/tests/src/Unit/Form/ReviewListFormTest.php
+++ b/web/modules/custom/dbcdk_community_moderation/tests/src/Unit/Form/ReviewListFormTest.php
@@ -97,7 +97,10 @@ class ReviewListFormTest extends UnitTestBase {
       ->expects($this->once())
       ->method('reviewCount')
       ->with(json_encode([
-        'markedAsDeleted' => ['neq' => TRUE],
+        'or' => [
+          ['markedAsDeleted' => NULL],
+          ['markedAsDeleted' => FALSE],
+        ],
         'libraryid' => ['inq' => [$library_id]],
       ]))
       ->willReturn((new InlineResponse200())->setCount(1));
@@ -108,7 +111,10 @@ class ReviewListFormTest extends UnitTestBase {
       ->method('reviewFind')
       ->with(json_encode([
         'where' => [
-          'markedAsDeleted' => ['neq' => TRUE],
+          'or' => [
+            ['markedAsDeleted' => NULL],
+            ['markedAsDeleted' => FALSE],
+          ],
           'libraryid' => ['inq' => [$library_id]],
         ],
         'offset' => 0,
@@ -141,7 +147,14 @@ class ReviewListFormTest extends UnitTestBase {
     $this->reviewApi
       ->expects($this->once())
       ->method('reviewFind')
-      ->with(json_encode(['where' => ['markedAsDeleted' => ['neq' => TRUE]]]))
+      ->with(json_encode([
+        'where' => [
+          'or' => [
+            ['markedAsDeleted' => NULL],
+            ['markedAsDeleted' => FALSE],
+          ],
+        ],
+      ]))
       ->willReturn($reviews);
     // We expect a warning though.
     $this->logger->expects($this->once())->method('warning');


### PR DESCRIPTION
Updated generator to generators where markedAsDeleted is set to NULL as
well.
