### PR TITLE
More fixes for review filtering

### DIFF
--- a/web/modules/custom/dbcdk_community_moderation/src/Form/ReviewListForm.php
+++ b/web/modules/custom/dbcdk_community_moderation/src/Form/ReviewListForm.php
@@ -139,23 +139,30 @@ class ReviewListForm extends FormBase {
     ];
 
     $filter = new \stdClass();
+    $filter->and = [];
     // Make sure we only get reviews that have not been deleted.
     // markedAsDeleted support TRUE, FALSE and NULL. In this regard not deleted
     // is regarded as NULL or FALSE. Use an OR filter as INQ and NEQ operators
     // do not support NULL properly.
-    $filter->or = [
-      ['markedAsDeleted' => NULL],
-      ['markedAsDeleted' => FALSE],
+    $filter->and[] = [
+      'or' => [
+        ['markedAsDeleted' => NULL],
+        ['markedAsDeleted' => FALSE],
+      ],
     ];
     // User-input filters.
     if (!empty($input['library_id'])) {
       $library_ids = explode(',', $input['library_id']);
-      $filter->libraryid = ['inq' => $library_ids];
+      $filter->and[] = ['libraryid' => ['inq' => $library_ids]];
     }
     if (!empty($input['content'])) {
       // We have to use regular expressions to support case insensitive
       // filtering.
-      $filter->content = ['regexp' => '/' . $input['content'] . '/i'];
+      $filter->and[] = [
+        'content' => [
+          'regexp' => '/' . $input['content'] . '/i',
+        ],
+      ];
     }
     $page_filter = ['where' => $filter];
 

--- a/web/modules/custom/dbcdk_community_moderation/tests/src/Unit/Form/ReviewListFormTest.php
+++ b/web/modules/custom/dbcdk_community_moderation/tests/src/Unit/Form/ReviewListFormTest.php
@@ -97,11 +97,15 @@ class ReviewListFormTest extends UnitTestBase {
       ->expects($this->once())
       ->method('reviewCount')
       ->with(json_encode([
-        'or' => [
-          ['markedAsDeleted' => NULL],
-          ['markedAsDeleted' => FALSE],
+        'and' => [
+          [
+            'or' => [
+              ['markedAsDeleted' => NULL],
+              ['markedAsDeleted' => FALSE],
+            ],
+          ],
+          ['libraryid' => ['inq' => [$library_id]]],
         ],
-        'libraryid' => ['inq' => [$library_id]],
       ]))
       ->willReturn((new InlineResponse200())->setCount(1));
 
@@ -111,11 +115,15 @@ class ReviewListFormTest extends UnitTestBase {
       ->method('reviewFind')
       ->with(json_encode([
         'where' => [
-          'or' => [
-            ['markedAsDeleted' => NULL],
-            ['markedAsDeleted' => FALSE],
+          'and' => [
+            [
+              'or' => [
+                ['markedAsDeleted' => NULL],
+                ['markedAsDeleted' => FALSE],
+              ],
+            ],
+            ['libraryid' => ['inq' => [$library_id]]],
           ],
-          'libraryid' => ['inq' => [$library_id]],
         ],
         'offset' => 0,
         'limit' => 10,
@@ -149,9 +157,13 @@ class ReviewListFormTest extends UnitTestBase {
       ->method('reviewFind')
       ->with(json_encode([
         'where' => [
-          'or' => [
-            ['markedAsDeleted' => NULL],
-            ['markedAsDeleted' => FALSE],
+          'and' => [
+            [
+              'or' => [
+                ['markedAsDeleted' => NULL],
+                ['markedAsDeleted' => FALSE],
+              ],
+            ],
           ],
         ],
       ]))


### PR DESCRIPTION
We need to use an explicit AND clause to make it work.

Update tests accordingly.
