### PR TITLE
Support background color + image on coloured header

### DIFF
--- a/web/config/sync/core.entity_form_display.paragraph.colored_header.default.yml
+++ b/web/config/sync/core.entity_form_display.paragraph.colored_header.default.yml
@@ -3,17 +3,27 @@ langcode: da
 status: true
 dependencies:
   config:
+    - field.field.paragraph.colored_header.field_background_image
     - field.field.paragraph.colored_header.field_color
     - field.field.paragraph.colored_header.field_text
     - field.field.paragraph.colored_header.field_title
+    - image.style.thumbnail
     - paragraphs.paragraphs_type.colored_header
   module:
     - color_field
+    - image
 id: paragraph.colored_header.default
 targetEntityType: paragraph
 bundle: colored_header
 mode: default
 content:
+  field_background_image:
+    weight: 3
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+    type: image_image
   field_color:
     weight: 2
     settings:
@@ -41,4 +51,5 @@ content:
     type: string_textfield
 hidden:
   created: true
+  status: true
   uid: true

--- a/web/config/sync/core.entity_view_display.paragraph.colored_header.default.yml
+++ b/web/config/sync/core.entity_view_display.paragraph.colored_header.default.yml
@@ -3,17 +3,28 @@ langcode: da
 status: true
 dependencies:
   config:
+    - field.field.paragraph.colored_header.field_background_image
     - field.field.paragraph.colored_header.field_color
     - field.field.paragraph.colored_header.field_text
     - field.field.paragraph.colored_header.field_title
+    - image.style.thumbnail
     - paragraphs.paragraphs_type.colored_header
   module:
     - color_field
+    - image
 id: paragraph.colored_header.default
 targetEntityType: paragraph
 bundle: colored_header
 mode: default
 content:
+  field_background_image:
+    weight: 3
+    label: above
+    settings:
+      image_style: thumbnail
+      image_link: file
+    third_party_settings: {  }
+    type: image
   field_color:
     weight: 2
     label: above

--- a/web/config/sync/field.field.paragraph.colored_header.field_background_image.yml
+++ b/web/config/sync/field.field.paragraph.colored_header.field_background_image.yml
@@ -1,0 +1,38 @@
+uuid: 7fd71cf6-2042-40f7-80dd-09843faab90d
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_background_image
+    - paragraphs.paragraphs_type.colored_header
+  module:
+    - image
+id: paragraph.colored_header.field_background_image
+field_name: field_background_image
+entity_type: paragraph
+bundle: colored_header
+label: 'Background image'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: false
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/web/config/sync/field.field.paragraph.colored_header.field_color.yml
+++ b/web/config/sync/field.field.paragraph.colored_header.field_color.yml
@@ -11,7 +11,7 @@ id: paragraph.colored_header.field_color
 field_name: field_color
 entity_type: paragraph
 bundle: colored_header
-label: Color
+label: 'Background color'
 description: ''
 required: false
 translatable: false

--- a/web/modules/custom/dbcdk_community_content/dbcdk_community_content.services.yml
+++ b/web/modules/custom/dbcdk_community_content/dbcdk_community_content.services.yml
@@ -22,6 +22,8 @@ services:
     class: Drupal\dbcdk_community_content\Normalizer\Widget\FactBoxWidgetNormalizer
   dbcdk_community_content.normalizer.widget.colored_header:
     class: Drupal\dbcdk_community_content\Normalizer\Widget\ColoredHeaderWidgetNormalizer
+    arguments:
+      - '@dbcdk_community_content.file_storage'
   dbcdk_community_content.normalizer.widget.full_width_banner:
     class: Drupal\dbcdk_community_content\Normalizer\Widget\FullWidthBannerWidgetNormalizer
     arguments:

--- a/web/modules/custom/dbcdk_community_content/src/Normalizer/Widget/ColoredHeaderWidgetNormalizer.php
+++ b/web/modules/custom/dbcdk_community_content/src/Normalizer/Widget/ColoredHeaderWidgetNormalizer.php
@@ -11,7 +11,7 @@ use Drupal\dbcdk_community_content\FieldNormalizer\StringItemFieldNormalizer;
  *
  * @see https://github.com/DBCDK/biblo/tree/master/src/client/components/WidgetContainer/widgets/ColoredHeaderWidget
  */
-class ColoredHeaderWidgetNormalizer extends WidgetNormalizer {
+class ColoredHeaderWidgetNormalizer extends DefaultWidgetNormalizer {
 
   /**
    * {@inheritdoc}
@@ -37,13 +37,7 @@ class ColoredHeaderWidgetNormalizer extends WidgetNormalizer {
       'text' => $stringNormalizer->normalize($object->get('field_text')->first()),
     ];
 
-    // If we have a color then add it. The field is optional.
-    $color = (new ColorFieldNormalizer())->normalize($object->get('field_color')->first());
-    if (!empty($color)) {
-      $config['color'] = $color;
-    }
-
-    return $config;
+    return $config + parent::getWidgetConfig($object);
   }
 
 }


### PR DESCRIPTION
- Extend the paragraph type for the widget with default fields.
- Use the default widget normalizer as parent
