### PR TITLE
Mark campaign images for permanent storage

### DIFF
--- a/web/config/sync/views.view.files.yml
+++ b/web/config/sync/views.view.files.yml
@@ -515,63 +515,6 @@ display:
           plugin_id: field
           entity_type: file
           entity_field: changed
-        count:
-          id: count
-          table: file_usage
-          field: count
-          relationship: fid
-          group_type: sum
-          admin_label: ''
-          label: 'Used in'
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: true
-            path: 'admin/content/files/usage/{{ fid }}'
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          set_precision: false
-          precision: 0
-          decimal: .
-          separator: ','
-          format_plural: true
-          format_plural_string: "1 place\x03@count places"
-          prefix: ''
-          suffix: ''
-          plugin_id: numeric
       filters:
         filename:
           id: filename
@@ -786,6 +729,7 @@ display:
         style: false
         row: false
         relationships: false
+        sorts: false
       pager:
         type: mini
         options:
@@ -809,56 +753,6 @@ display:
         operator: AND
         groups: {  }
       fields:
-        entity_label:
-          id: entity_label
-          table: file_usage
-          field: entity_label
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: Entity
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          link_to_entity: true
-          plugin_id: entity_label
         type:
           id: type
           table: file_usage
@@ -1114,6 +1008,7 @@ display:
           admin_label: 'File usage'
           required: true
       display_extenders: {  }
+      sorts: {  }
     cache_metadata:
       contexts:
         - 'languages:language_interface'

--- a/web/modules/custom/dbcdk_community_content/dbcdk_community_content.services.yml
+++ b/web/modules/custom/dbcdk_community_content/dbcdk_community_content.services.yml
@@ -78,5 +78,8 @@ services:
       - '@dbcdk_community.api.campaign'
       - '@dbcdk_community.api.campaign_work_type'
       - '@dbcdk_community.api.group'
+      - '@dbcdk_community_content.file_storage'
+      - '@file.usage'
+      - '@dbcdk_community_content.image_style_storage'
     calls:
       - [setLogger, ['@dbcdk_community.logger']]

--- a/web/modules/custom/dbcdk_community_content/src/Campaign/Campaign.php
+++ b/web/modules/custom/dbcdk_community_content/src/Campaign/Campaign.php
@@ -4,6 +4,7 @@ namespace Drupal\dbcdk_community_content\Campaign;
 
 use \DBCDK\CommunityServices\Model\Campaign as ModelCampaign;
 use DBCDK\CommunityServices\Model\Group;
+use Drupal\file\FileInterface;
 
 /**
  * Campaign model.
@@ -21,11 +22,27 @@ class Campaign extends ModelCampaign {
   protected $group;
 
   /**
-   * Thw work types related to the campaign.
+   * The work types related to the campaign.
    *
    * @var \DBCDK\CommunityServices\Model\CampaignWorktype[]
    */
   protected $workTypes;
+
+  /**
+   * The logo for the campaign in pxiel format.
+   *
+   * This will be a JPEG, PNG or the like.
+   *
+   * @var FileInterface
+   */
+  protected $imgLogo;
+
+  /**
+   * The logo for the campaign in SVG format.
+   *
+   * @var FileInterface
+   */
+  protected $svgLogo;
 
   /**
    * Campaign constructor.
@@ -33,12 +50,9 @@ class Campaign extends ModelCampaign {
    * @param \DBCDK\CommunityServices\Model\Campaign|null $campaign
    *   The generated campaign class to base the object on.
    */
-  public function __construct(ModelCampaign $campaign = NULL, Group $group = NULL, array $work_types = []) {
+  public function __construct(ModelCampaign $campaign = NULL) {
     $data = (!empty($campaign)) ? $campaign->container : [];
     parent::__construct($data);
-
-    $this->group = $group;
-    $this->workTypes = $work_types;
   }
 
   /**
@@ -68,7 +82,7 @@ class Campaign extends ModelCampaign {
    *   Work types used by this campaign.
    */
   public function getWorkTypes() {
-    return $this->workTypes;
+    return (array) $this->workTypes;
   }
 
   /**
@@ -79,6 +93,46 @@ class Campaign extends ModelCampaign {
    */
   public function setWorkTypes(array $workTypes) {
     $this->workTypes = $workTypes;
+  }
+
+  /**
+   * Get the logo image file.
+   *
+   * @return FileInterface
+   *   Logo image file.
+   */
+  public function getImgLogo() {
+    return $this->imgLogo;
+  }
+
+  /**
+   * Set the logo image file.
+   *
+   * @param FileInterface $imgLogo
+   *   The logo image file to set.
+   */
+  public function setImgLogo(FileInterface $imgLogo) {
+    $this->imgLogo = $imgLogo;
+  }
+
+  /**
+   * Set the logo vector file.
+   *
+   * @return FileInterface
+   *   The vector logo file.
+   */
+  public function getSvgLogo() {
+    return $this->svgLogo;
+  }
+
+  /**
+   * Set the logo vector file.
+   *
+   * @param FileInterface $svgLogo
+   *   The vector logo file to set.
+   */
+  public function setSvgLogo(FileInterface $svgLogo) {
+    $this->svgLogo = $svgLogo;
   }
 
 }

--- a/web/modules/custom/dbcdk_community_content/src/Form/CampaignForm.php
+++ b/web/modules/custom/dbcdk_community_content/src/Form/CampaignForm.php
@@ -5,17 +5,12 @@ namespace Drupal\dbcdk_community_content\Form;
 use DBCDK\CommunityServices\Api\GroupApi;
 use DBCDK\CommunityServices\ApiException;
 use DBCDK\CommunityServices\Model\CampaignWorktype;
-use Drupal\Component\Utility\UrlHelper;
 use Drupal\Core\Datetime\DrupalDateTime;
-use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\StreamWrapper\PublicStream;
 use Drupal\Core\Url;
 use Drupal\dbcdk_community_content\Campaign\Campaign;
 use Drupal\dbcdk_community_content\Campaign\CampaignRepository;
-use Drupal\file\FileStorageInterface;
-use Drupal\image\Entity\ImageStyle;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -50,20 +45,6 @@ class CampaignForm extends FormBase {
   protected $campaign;
 
   /**
-   * The file storage to use when managed uploaded campaign files.
-   *
-   * @var FileStorageInterface
-   */
-  protected $fileStorage;
-
-  /**
-   * The image style storage to use to determine derivatives of images.
-   *
-   * @var EntityStorageInterface
-   */
-  protected $imageStyleStorage;
-
-  /**
    * CampaignForm constructor.
    *
    * @param LoggerInterface $logger
@@ -74,25 +55,17 @@ class CampaignForm extends FormBase {
    *   The group api to use.
    * @param Campaign $campaign
    *   The campaign to manage.
-   * @param FileStorageInterface $file_storage
-   *   The file storage to use.
-   * @param EntityStorageInterface $image_style_storage
-   *   The image style storage to use.
    */
   public function __construct(
     LoggerInterface $logger,
     CampaignRepository $campaign_repository,
     GroupApi $group_api,
-    Campaign $campaign,
-    FileStorageInterface $file_storage,
-    EntityStorageInterface $image_style_storage
+    Campaign $campaign
   ) {
     $this->logger = $logger;
     $this->campaignRepository = $campaign_repository;
     $this->groupApi = $group_api;
     $this->campaign = $campaign;
-    $this->fileStorage = $file_storage;
-    $this->imageStyleStorage = $image_style_storage;
   }
 
   /**
@@ -121,9 +94,7 @@ class CampaignForm extends FormBase {
       $logger,
       $campaign_repository,
       $container->get('dbcdk_community.api.group'),
-      $campaign,
-      $container->get('dbcdk_community_content.file_storage'),
-      $container->get('dbcdk_community_content.image_style_storage')
+      $campaign
     );
   }
 
@@ -219,15 +190,13 @@ class CampaignForm extends FormBase {
     // though they are required by the service.
     $logo_img_fids = [];
     $logo_img_url = $this->t('Not set');
-    // Try to determine field id based on the small version of the logo.
-    // If we manage the file then small, medium and large logos will be
-    // derivations of the same image using image styles.
+    if ($this->campaign->getImgLogo()) {
+      $logo_img_fids[] = $this->campaign->getImgLogo()->id();
+    }
+    // Get the raw file url from the remote object. The could be a local or
+    // remote url depending on where the image is stored.
     if (!empty($this->campaign->getLogos()['small'])) {
       $logo_img_url = $this->campaign->getLogos()['small'];
-      $file = $this->loadFileFromUrl($this->campaign->getLogos()['small']);
-      if (!empty($file)) {
-        $logo_img_fids[] = $file->id();
-      }
     }
     $form['logo_img'] = array(
       '#type' => 'managed_file',
@@ -242,12 +211,11 @@ class CampaignForm extends FormBase {
 
     $logo_svg_fids = [];
     $logo_svg_url = $this->t('Not set');
+    if (!empty($this->campaign->getSvgLogo())) {
+      $logo_svg_fids[] = $this->campaign->getSvgLogo()->id();
+    }
     if (!empty($this->campaign->getLogos()['svg'])) {
       $logo_svg_url = $this->campaign->getLogos()['svg'];
-      $file = $this->loadFileFromUrl($this->campaign->getLogos()['svg']);
-      if (!empty($file)) {
-        $logo_svg_fids[] = $file->id();
-      }
     }
     $form['logo_svg'] = array(
       '#type' => 'managed_file',
@@ -321,57 +289,16 @@ class CampaignForm extends FormBase {
     $end->setTime(23, 59, 59);
     $this->campaign->setEndDate($end);
 
-    $logos = (array) $this->campaign->getLogos();
-    $new_files = [];
-
     if (!empty($form['logo_img']['#files'])) {
       // If a logo image has been uploaded then manage it.
       /* @var \Drupal\file\Entity\File $logo_img */
-      $logo_img = array_shift($form['logo_img']['#files']);
-      if ($logo_img->isNew()) {
-        // Mark new images for permanent storage. Otherwise they will be cleaned
-        // up at some point.
-        $logo_img->setPermanent();
-        $logo_img->save();
-      }
-
-      // Get image styles to match required versions.
-      $image_styles = array_reduce(
-        ['small', 'medium', 'large'],
-        function ($image_styles, $image_style_name) {
-          $image_styles[$image_style_name] = $this->imageStyleStorage->load(
-            $image_style_name
-          );
-          // Remove nonexistant image styles - where load has returned null.
-          return array_filter($image_styles);
-        },
-        []
-      );
-
-      // Build array of urls to logo files. We override preexisting values.
-      $logos = array_merge($logos, array_map(
-        function (ImageStyle $style) use ($logo_img) {
-          return $style->buildUrl($logo_img->get('uri')->getString());
-        },
-        $image_styles
-      ));
+      $this->campaign->setImgLogo(array_shift($form['logo_img']['#files']));
     }
 
     if (!empty($form['logo_svg']['#files'])) {
       // Manage SVG logos as well.
       /* @var \Drupal\file\Entity\File $logo_svg */
-      $logo_svg = array_shift($form['logo_svg']['#files']);
-      if ($logo_svg->isNew()) {
-        $logo_svg->setPermanent();
-        $logo_svg->save();
-      }
-      // We can just set the raw URL to the SVG. There is no need to create
-      // derivatives of vectors.
-      $logos['svg'] = file_create_url($logo_svg->getFileUri());
-    }
-
-    if (!empty($logos)) {
-      $this->campaign->setLogos($logos);
+      $this->campaign->setSvgLogo(array_shift($form['logo_svg']['#files']));
     }
 
     try {
@@ -391,43 +318,6 @@ class CampaignForm extends FormBase {
       $this->logger->error($e);
       drupal_set_message($this->t('Unable to create/update the campaign. Please try again later'), 'error');
     }
-  }
-
-  /**
-   * Load a File entity based on a public url.
-   *
-   * @param string $url
-   *   The url for which to load the file.
-   *
-   * @return File|Null
-   *   The file corresponding to the url. NULL if there are no corresponding
-   *   files.
-   */
-  protected function loadFileFromUrl($url) {
-    try {
-      $local = UrlHelper::externalIsLocal($url, $this->getRequest()->getSchemeAndHttpHost());
-    }
-    catch (\InvalidArgumentException $e) {
-      $local = FALSE;
-    }
-    if (!$local) {
-      // If the file is not local then we cannot possibly load a file.
-      return NULL;
-    }
-
-    // Do convertions:
-    // 1. Convert from full urls to stream wrapper.
-    $url = str_replace(PublicStream::baseUrl(), 'public:/', $url);
-    // 2. Remove image style path prefixes.
-    $url = str_replace('/styles/small/public', '', $url);
-    // 3. Remove query parameters such a itok.
-    $url = explode('?', $url, 2)[0];
-    // 4. Decode url parameters.
-    $url = urldecode($url);
-
-    // Load and return the first file.
-    $files = $this->fileStorage->loadByProperties(['uri' => $url]);
-    return array_shift($files);
   }
 
 }


### PR DESCRIPTION
This requires us to properly mark uploaded files as permanent and 
register/deregister usage of them. Otherwise updates of existing
campaigns are not possible due to validation for managed_file form
elements.

To achieve this file fields have been added to the Campaign model and 
the Campaign repository have been updated to handle loading and saving
of campaign files. Corresponding logic has been removed from the
Campaign form.

File usage expects referenced types to be entities. That is not the
case for us but we still need to register usage. Consequently we remove
the file usage field + link from the files list view.

This fixes #149.
